### PR TITLE
feat: export doris write error to spark master, no need to check executor log

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -211,6 +211,7 @@ public class DorisStreamLoad implements Serializable{
         LOG.debug("Streamload Request:{} ,Body:{}", loadUrlStr, value);
         LoadResponse loadResponse = loadBatch(value);
         if(loadResponse.status != 200){
+            LOG.info("Streamload Response HTTP Status Error:{}",loadResponse);
             throw new StreamLoadException("stream load error: " + loadResponse.respContent);
         }else{
             LOG.info("Streamload Response:{}",loadResponse);
@@ -218,6 +219,7 @@ public class DorisStreamLoad implements Serializable{
             try {
                 RespContent respContent = obj.readValue(loadResponse.respContent, RespContent.class);
                 if(!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())){
+                    LOG.info("Streamload Response RES STATUS Error:{}", loadResponse);
                     throw new StreamLoadException("stream load error: " + respContent.getMessage());
                 }
             } catch (IOException e) {

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
@@ -111,7 +111,6 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
                   Thread.sleep(1000 * i)
                 } catch {
                   case ex: InterruptedException =>
-                    logger.warn("Data that failed to load : " + dorisStreamLoader.listToString(rowsBuffer))
                     Thread.currentThread.interrupt()
                     throw new IOException("unable to flush; interrupted while doing another attempt", e)
                 }
@@ -119,7 +118,6 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
           }
 
           if (!rowsBuffer.isEmpty) {
-            logger.warn("Data that failed to load : " + dorisStreamLoader.listToString(rowsBuffer))
             throw new IOException(s"Failed to load ${maxRowCount} batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", err)
           }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

For example, suppose we try to write data to a table a, and doris has not yet created a new table, the current version, we get the error message 

```Failed to load data on BE: http:xxx```

There is no error detail information.

With the improvements, we get an error message like this.

```
Caused by: org.apache.doris.spark.exception.StreamLoadException: stream load error: errCode = 7, detailMessage = unknown table, tableName=token _price_nick_new2
```
