### PR TITLE
Spark 3.3.0 support

### DIFF
--- a/spark-doris-connector/build.sh
+++ b/spark-doris-connector/build.sh
@@ -95,10 +95,10 @@ done
 
 # extract minor version:
 # eg: 3.1.2 -> 3
-SPARK_MINOR_VERSION=0
+SPARK_MAJOR_VERSION=0
 if [ ${SPARK_VERSION} != 0 ]; then
-    SPARK_MINOR_VERSION=${SPARK_VERSION%.*}
-    echo "SPARK_MINOR_VERSION: ${SPARK_MINOR_VERSION}"
+    SPARK_MAJOR_VERSION=${SPARK_VERSION%.*}
+    echo "SPARK_MAJOR_VERSION: ${SPARK_MAJOR_VERSION}"
 fi
 
 if [[ ${BUILD_FROM_TAG} -eq 1 ]]; then
@@ -106,7 +106,7 @@ if [[ ${BUILD_FROM_TAG} -eq 1 ]]; then
     ${MVN_BIN} clean package
 else
     rm -rf ${ROOT}/output/
-    ${MVN_BIN} clean package -Dspark.version=${SPARK_VERSION} -Dscala.version=${SCALA_VERSION} -Dspark.minor.version=${SPARK_MINOR_VERSION} $MVN_ARGS
+    ${MVN_BIN} clean package -Dspark.version=${SPARK_VERSION} -Dscala.version=${SCALA_VERSION} -Dspark.major.version=${SPARK_MAJOR_VERSION} $MVN_ARGS
 fi
 
 mkdir ${ROOT}/output/

--- a/spark-doris-connector/pom.xml
+++ b/spark-doris-connector/pom.xml
@@ -26,7 +26,7 @@
         <version>23</version>
     </parent>
     <groupId>org.apache.doris</groupId>
-    <artifactId>spark-doris-connector-${spark.minor.version}_${scala.version}</artifactId>
+    <artifactId>spark-doris-connector-${spark.major.version}_${scala.version}</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>Spark Doris Connector</name>
     <url>https://doris.apache.org/</url>
@@ -64,7 +64,7 @@
     <properties>
         <scala.version>${env.scala.version}</scala.version>
         <spark.version>${env.spark.version}</spark.version>
-        <spark.minor.version>${env.spark.minor.version}</spark.minor.version>
+        <spark.major.version>${env.spark.major.version}</spark.major.version>
         <libthrift.version>0.13.0</libthrift.version>
         <arrow.version>5.0.0</arrow.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -285,6 +285,7 @@
                         <phase>process-resources</phase>
                         <goals>
                             <goal>compile</goal>
+                            <goal>add-source</goal>
                         </goals>
                     </execution>
                     <execution>

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/ScalaValueReader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/ScalaValueReader.scala
@@ -31,10 +31,9 @@ import org.apache.doris.spark.rest.PartitionDefinition
 import org.apache.doris.spark.rest.models.Schema
 import org.apache.doris.spark.serialization.{Routing, RowBatch}
 import org.apache.doris.spark.sql.SchemaUtils
-import org.apache.doris.spark.util.ErrorMessages
 import org.apache.doris.spark.util.ErrorMessages.SHOULD_NOT_HAPPEN_MESSAGE
 import org.apache.doris.thrift.{TScanCloseParams, TScanNextBatchParams, TScanOpenParams, TScanOpenResult}
-import org.apache.log4j.Logger
+import org.apache.spark.internal.Logging
 
 import scala.util.control.Breaks
 
@@ -43,8 +42,7 @@ import scala.util.control.Breaks
  * @param partition Doris RDD partition
  * @param settings request configuration
  */
-class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
-  private val logger = Logger.getLogger(classOf[ScalaValueReader])
+class ScalaValueReader(partition: PartitionDefinition, settings: Settings) extends Logging {
 
   protected val client = new BackendClient(new Routing(partition.getBeAddress), settings)
   protected val clientLock =
@@ -57,7 +55,7 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
   protected lazy val deserializeArrowToRowBatchAsync: Boolean = Try {
     settings.getProperty(DORIS_DESERIALIZE_ARROW_ASYNC, DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT.toString).toBoolean
   } getOrElse {
-    logger.warn(ErrorMessages.PARSE_BOOL_FAILED_MESSAGE, DORIS_DESERIALIZE_ARROW_ASYNC, settings.getProperty(DORIS_DESERIALIZE_ARROW_ASYNC))
+    logWarning(s"Parse '${DORIS_DESERIALIZE_ARROW_ASYNC}' to boolean failed. Original string is '${settings.getProperty(DORIS_DESERIALIZE_ARROW_ASYNC)}'." )
     DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT
   }
 
@@ -65,7 +63,7 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
     val blockingQueueSize = Try {
       settings.getProperty(DORIS_DESERIALIZE_QUEUE_SIZE, DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT.toString).toInt
     } getOrElse {
-      logger.warn(ErrorMessages.PARSE_NUMBER_FAILED_MESSAGE, DORIS_DESERIALIZE_QUEUE_SIZE, settings.getProperty(DORIS_DESERIALIZE_QUEUE_SIZE))
+      logWarning(s"Parse '${DORIS_DESERIALIZE_QUEUE_SIZE}' to number failed. Original string is '${settings.getProperty(DORIS_DESERIALIZE_QUEUE_SIZE)}'.")
       DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT
     }
 
@@ -89,21 +87,21 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
     val batchSize = Try {
       settings.getProperty(DORIS_BATCH_SIZE, DORIS_BATCH_SIZE_DEFAULT.toString).toInt
     } getOrElse {
-        logger.warn(ErrorMessages.PARSE_NUMBER_FAILED_MESSAGE, DORIS_BATCH_SIZE, settings.getProperty(DORIS_BATCH_SIZE))
+        logWarning(s"Parse '${DORIS_BATCH_SIZE}' to number failed. Original string is '${settings.getProperty(DORIS_BATCH_SIZE)}'." )
         DORIS_BATCH_SIZE_DEFAULT
     }
 
     val queryDorisTimeout = Try {
       settings.getProperty(DORIS_REQUEST_QUERY_TIMEOUT_S, DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT.toString).toInt
     } getOrElse {
-      logger.warn(ErrorMessages.PARSE_NUMBER_FAILED_MESSAGE, DORIS_REQUEST_QUERY_TIMEOUT_S, settings.getProperty(DORIS_REQUEST_QUERY_TIMEOUT_S))
+      logWarning(s"Parse '${DORIS_REQUEST_QUERY_TIMEOUT_S}' to number failed. Original string is '${settings.getProperty(DORIS_REQUEST_QUERY_TIMEOUT_S)}'.")
       DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT
     }
 
     val execMemLimit = Try {
       settings.getProperty(DORIS_EXEC_MEM_LIMIT, DORIS_EXEC_MEM_LIMIT_DEFAULT.toString).toLong
     } getOrElse {
-      logger.warn(ErrorMessages.PARSE_NUMBER_FAILED_MESSAGE, DORIS_EXEC_MEM_LIMIT, settings.getProperty(DORIS_EXEC_MEM_LIMIT))
+      logWarning(s"Parse '${DORIS_EXEC_MEM_LIMIT}' to number failed. Original string is '${settings.getProperty(DORIS_EXEC_MEM_LIMIT)}'.")
       DORIS_EXEC_MEM_LIMIT_DEFAULT
     }
 
@@ -113,7 +111,7 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
     params.setUser(settings.getProperty(DORIS_REQUEST_AUTH_USER, ""))
     params.setPasswd(settings.getProperty(DORIS_REQUEST_AUTH_PASSWORD, ""))
 
-    logger.debug(s"Open scan params is, " +
+    logDebug(s"Open scan params is, " +
         s"cluster: ${params.getCluster}, " +
         s"database: ${params.getDatabase}, " +
         s"table: ${params.getTable}, " +
@@ -159,7 +157,7 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
     started
   }
 
-  logger.debug(s"Open scan result is, contextId: $contextId, schema: $schema.")
+  logDebug(s"Open scan result is, contextId: $contextId, schema: $schema.")
 
   /**
    * read data and cached in rowBatch.
@@ -213,7 +211,7 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) {
    */
   def next: AnyRef = {
     if (!hasNext) {
-      logger.error(SHOULD_NOT_HAPPEN_MESSAGE)
+      logError(SHOULD_NOT_HAPPEN_MESSAGE)
       throw new ShouldNeverHappenException
     }
     rowBatch.next


### PR DESCRIPTION
# Proposed changes
1. Support Spark 3.3.0
Removed  log4j 1.x, and uses Spark's Logging trait, which uses log4j 2.x in Sprak 3.3.0. For older Spark versions , this change does not break the compability.  Code changes are in `ScalaValueReader.scala`

2. Close BufferedReader in DorisStreamLoad
When reading Doris BE rest api's response, BufferedReader should be closed in `DorisStreamLoad` , function: `loadBatch`

3. Change spark.minor.version to spark.major.version
In pom.xml, the property `spark.minor.version` is actually spark major version. 

5. source jar to include scala code
changes in pom.xml scala-maven-plugin

Issue Number: close #xxx

## Problem Summary:
This pr upgrades the code to support Spark 3.3.0, as well as other minor changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
No
3. Has unit tests been added: (Yes/No/No Need)
No unit test is added, but tested manually. in spark-sql CLI.

5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments
If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

## Test results:
Versions: 
- spark-3.3.0-bin-hadoop3
- JDK 1.8

1.  truncate Doris table from CLI
![image](https://user-images.githubusercontent.com/12869649/207050768-df732160-33d3-4395-87ef-e3141d6bc663.png)

2. Create spark view and insert data into Doris table
Start `spark-sql` CLI in local mode and execute: 
```
CREATE TEMPORARY VIEW spark_doris
USING doris
OPTIONS(
  "table.identifier"="zjc_1.table_hash",
  "fenodes"="localhost:8030",
  "user"="zjc",
  "password"="******"
);
insert into spark_doris select 5,15.0;
```
4. Check data in Doris
![image](https://user-images.githubusercontent.com/12869649/207051363-c77e59c5-fa5b-4527-b94b-9829913b48ae.png)

6. Select data in spark-sql
`select * from spark_doris;`
![image](https://user-images.githubusercontent.com/12869649/207051565-582853ab-b8bf-4b8e-8ad5-dff17d7277aa.png)

## How to build spark-doris-connector for  Spark 3.3.0
Run  the command:
`sh build.sh --spark 3.3.0 --scala 2.12`


