### PR TITLE
[improvement]Add an option to set the partition size of the final write stage

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -75,4 +75,14 @@ public interface ConfigurationOptions {
     String DORIS_MAX_FILTER_RATIO = "doris.max.filter.ratio";
 
     String STREAM_LOAD_PROP_PREFIX = "doris.sink.properties.";
+
+    String DORIS_SINK_TASK_PARTITION_SIZE = "doris.sink.task.partition.size";
+
+    /**
+     * Set doris sink task partition size. If you set a small coalesce size and you don't have the action operations, this may result in the same parallelism in your computation.
+     * To avoid this, you can use repartition operations. This will add a shuffle step, but means the current upstream partitions will be executed in parallel.
+     */
+    String DORIS_SINK_TASK_USE_REPARTITION = "doris.sink.task.use.repartition";
+
+    boolean DORIS_SINK_TASK_USE_REPARTITION_DEFAULT = false;
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/Settings.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/Settings.java
@@ -47,7 +47,11 @@ public abstract class Settings {
         return value;
     }
 
-    public int getIntegerProperty(String name, int defaultValue) {
+    public Integer getIntegerProperty(String name) {
+        return getIntegerProperty(name, null);
+    }
+
+    public Integer getIntegerProperty(String name, Integer defaultValue) {
         try {
             if (getProperty(name) != null) {
                  return Integer.parseInt(getProperty(name));

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.slf4j.{Logger, LoggerFactory}
 import java.io.IOException
 import org.apache.doris.spark.rest.RestService
-
+import java.util.Objects
 import scala.util.control.Breaks
 
 private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSettings) extends Sink with Serializable {
@@ -35,6 +35,8 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
   @volatile private var latestBatchId = -1L
   val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
   val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_MAX_RETRIES, ConfigurationOptions.SINK_MAX_RETRIES_DEFAULT)
+  val sinkTaskPartitionSize = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_TASK_PARTITION_SIZE)
+  val sinkTaskUseRepartition = settings.getProperty(ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION, ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION_DEFAULT.toString).toBoolean
   val dorisStreamLoader: DorisStreamLoad = CachedDorisStreamLoadClient.getOrCreate(settings)
 
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
@@ -48,8 +50,12 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
 
   def write(queryExecution: QueryExecution): Unit = {
     val schema = queryExecution.analyzed.output
+    var resultRdd = queryExecution.toRdd
+    if (Objects.nonNull(sinkTaskPartitionSize)) {
+      resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
+    }
     // write for each partition
-    queryExecution.toRdd.foreachPartition(iter => {
+    resultRdd.foreachPartition(iter => {
       val objectMapper = new ObjectMapper()
       val rowArray = objectMapper.createArrayNode()
       iter.foreach(row => {


### PR DESCRIPTION
# Proposed changes

Add an option to set the partition size of the final write stage

1. We can increase the parallelism of the computation and reduce the write doris parallelism to reduce write compaction pressure.
2. After the spark RDD is filtered, the number of records for each partition is small and the number of partitions is large. The writing frequency becomes high and resources are wasted.




## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments
before :
![image](https://user-images.githubusercontent.com/39718951/207811635-368b8458-e466-445f-9302-23da1223d827.png)

after :
![image](https://user-images.githubusercontent.com/39718951/207810643-30499216-b69f-4f57-bd1c-da950f364eb5.png)

![image](https://user-images.githubusercontent.com/39718951/207810721-b15e386f-8485-4d13-8353-ba62efdf0e7e.png)

