### PR TITLE
[fix] cache loader cannot be serialized

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -94,12 +94,7 @@ public class DorisStreamLoad implements Serializable{
         this.streamLoadProp=getStreamLoadProp(settings);
         cache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
-                .build(new CacheLoader<String, List<BackendV2.BackendRowV2>>() {
-                    @Override
-                    public List<BackendV2.BackendRowV2> load(String key) throws IOException, DorisException {
-                        return RestService.getBackendRows(settings, LOG);
-                    }
-                });
+                .build(new BackendCacheLoader(settings));
     }
 
     public DorisStreamLoad(SparkSettings settings, String[] dfColumns) throws IOException, DorisException {
@@ -118,12 +113,7 @@ public class DorisStreamLoad implements Serializable{
         this.streamLoadProp=getStreamLoadProp(settings);
         cache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
-                .build(new CacheLoader<String, List<BackendV2.BackendRowV2>>() {
-                    @Override
-                    public List<BackendV2.BackendRowV2> load(String key) throws IOException, DorisException {
-                        return RestService.getBackendRows(settings, LOG);
-                    }
-                });
+                .build(new BackendCacheLoader(settings));
     }
 
     public String getLoadUrlStr() {
@@ -323,4 +313,23 @@ public class DorisStreamLoad implements Serializable{
             throw new RuntimeException("get backends info fail",e);
         }
     }
+
+    /**
+     * serializable be cache loader
+     */
+    private static class BackendCacheLoader extends CacheLoader<String, List<BackendV2.BackendRowV2>> implements Serializable {
+
+        private final SparkSettings settings;
+
+        public BackendCacheLoader(SparkSettings settings) {
+            this.settings = settings;
+        }
+
+        @Override
+        public List<BackendV2.BackendRowV2> load(String key) throws Exception {
+            return RestService.getBackendRows(settings, LOG);
+        }
+
+    }
+
 }


### PR DESCRIPTION
# Proposed changes

Since CacheLoader does not implement the Serializable interface, the anonymous inner class used to construct LoadingCache cannot be serialized.
The internal class BackendCacheLoader inherits CacheLoader and implements Serializable, which solves the problem that the anonymous internal class of CacheLoading cannot be serialized.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
