### PR TITLE
Fix `spark.minor.version` to `spark.major.version`

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -50,7 +50,7 @@ jobs:
           -Dspark.version=2.3.4 \
           -Dscala.version=2.11 \
           -Dthrift.binary=/usr/bin/thrift \
-          -Dspark.minor.version=2.3
+          -Dspark.major.version=2.3
 
     - name: Build spark connector v3
       run: |
@@ -58,6 +58,6 @@ jobs:
           -Dspark.version=3.1.2 \
           -Dscala.version=2.12 \
           -Dthrift.binary=/usr/bin/thrift \
-          -Dspark.minor.version=3.1
+          -Dspark.major.version=3.1
           
 

--- a/spark-doris-connector/build.sh
+++ b/spark-doris-connector/build.sh
@@ -181,20 +181,20 @@ elif [ ${SparkVer} -eq 4 ]; then
     SPARK_VERSION=$ver
 fi
 
-# extract minor version:
-# eg: 3.1.2 -> 3
-SPARK_MINOR_VERSION=0
-[ ${SPARK_VERSION} != 0 ] && SPARK_MINOR_VERSION=${SPARK_VERSION%.*}
+# extract major version:
+# eg: 3.1.2 -> 3.1
+SPARK_MAJOR_VERSION=0
+[ ${SPARK_VERSION} != 0 ] && SPARK_MAJOR_VERSION=${SPARK_VERSION%.*}
 
 echo_g " scala version: ${SCALA_VERSION}"
-echo_g " spark version: ${SPARK_VERSION}, minor version: ${SPARK_MINOR_VERSION}"
+echo_g " spark version: ${SPARK_VERSION}, major version: ${SPARK_MAJOR_VERSION}"
 echo_g " build starting..."
 
 ${MVN_BIN} clean package \
   -Dspark.version=${SPARK_VERSION} \
   -Dscala.version=${SCALA_VERSION} \
   -Dthrift.binary=${THRIFT_BIN} \
-  -Dspark.minor.version=${SPARK_MINOR_VERSION} "$@"
+  -Dspark.major.version=${SPARK_MAJOR_VERSION} "$@"
 
 EXIT_CODE=$?
 if [ $EXIT_CODE -eq 0 ]; then

--- a/spark-doris-connector/pom.xml
+++ b/spark-doris-connector/pom.xml
@@ -26,7 +26,7 @@
         <version>23</version>
     </parent>
     <groupId>org.apache.doris</groupId>
-    <artifactId>spark-doris-connector-${spark.minor.version}_${scala.version}</artifactId>
+    <artifactId>spark-doris-connector-${spark.major.version}_${scala.version}</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>Spark Doris Connector</name>
     <url>https://doris.apache.org/</url>
@@ -63,7 +63,7 @@
     </mailingLists>
     <properties>
         <spark.version>3.1.2</spark.version>
-        <spark.minor.version>3.1</spark.minor.version>
+        <spark.major.version>3.1</spark.major.version>
         <scala.version>2.12</scala.version>
         <libthrift.version>0.13.0</libthrift.version>
         <arrow.version>5.0.0</arrow.version>


### PR DESCRIPTION
# Proposed changes

Fix `spark.minor.version` to `spark.major.version` in build scripts and pom.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
