### PR TITLE
[Improve] Code improvement in loadBatch method of DorisStreamLoad

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -275,7 +275,7 @@ public class DorisStreamLoad implements Serializable {
             String respMsg = beConn.getResponseMessage();
             String response;
             try (InputStream beConnInputStream = beConn.getInputStream()) {
-                response = String.join("", IOUtils.readLines(IOUtils.toBufferedReader(new InputStreamReader(beConnInputStream))));
+                response = String.join("", IOUtils.readLines(new InputStreamReader(beConnInputStream)));
             }
             return new LoadResponse(status, respMsg, response);
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -216,7 +216,7 @@ public class DorisStreamLoad implements Serializable {
                 load(serializedRows);
             }
         } else {
-            throw new StreamLoadException("Not supoort the file format in stream load.");
+            throw new StreamLoadException(String.format("Not supported file format in stream load: %s.", fileType));
         }
     }
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -41,6 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 
 /**
@@ -183,19 +184,11 @@ public class DorisStreamLoad implements Serializable {
     }
 
     public String listToString(List<List<Object>> rows) {
-        StringJoiner lines = new StringJoiner(LINE_DELIMITER);
-        for (List<Object> row : rows) {
-            StringJoiner line = new StringJoiner(FIELD_DELIMITER);
-            for (Object field : row) {
-                if (field == null) {
-                    line.add(NULL_VALUE);
-                } else {
-                    line.add(field.toString());
-                }
-            }
-            lines.add(line.toString());
-        }
-        return lines.toString();
+        return rows.stream().map(row ->
+                row.stream().map(field ->
+                        (field == null) ? NULL_VALUE : field.toString()
+                ).collect(Collectors.joining(FIELD_DELIMITER))
+        ).collect(Collectors.joining(LINE_DELIMITER));
     }
 
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -34,10 +34,7 @@ import org.apache.doris.spark.util.ListUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Serializable;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -268,7 +265,9 @@ public class DorisStreamLoad implements Serializable {
             // build request and send to new be location
             beConn = getConnection(loadUrlStr, label);
             // send data to be
-            IOUtils.write(value, IOUtils.buffer(beConn.getOutputStream()), StandardCharsets.UTF_8);
+            try (OutputStream beConnOutputStream = new BufferedOutputStream(beConn.getOutputStream())) {
+                IOUtils.write(value, beConnOutputStream, StandardCharsets.UTF_8);
+            }
 
             // get respond
             status = beConn.getResponseCode();

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -216,7 +216,7 @@ public class DorisStreamLoad implements Serializable {
                 load(serializedRows);
             }
         } else {
-            throw new StreamLoadException(String.format("Not supported file format in stream load: %s.", fileType));
+            throw new StreamLoadException(String.format("Unsupported file format in stream load: %s.", fileType));
         }
     }
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -274,7 +274,7 @@ public class DorisStreamLoad implements Serializable {
             String respMsg = beConn.getResponseMessage();
             String response;
             try (InputStream beConnInputStream = beConn.getInputStream()) {
-                response = String.join("", IOUtils.readLines(new InputStreamReader(beConnInputStream)));
+                response = IOUtils.toString(beConnInputStream, StandardCharsets.UTF_8);
             }
             return new LoadResponse(status, respMsg, response);
 


### PR DESCRIPTION
# Proposed changes

1. use `IOUtils` of `commons-io` lib for less handling details of input/output stream processing
2. remove unused `feConn` variable
3. make sure `beConn`'s input / output stream closed right after being used
4. fix the name`authEncoding` to `authEncoded`, and extract the method `getAuthEncoded` to reduce redundant code.
5. fix typo in error message for unsupported file format 

## Problem Summary:



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
6. Has unit tests been added: (Yes/No/No Need)
7. Has document been added or modified: (Yes/No/No Need)
8. Does it need to update dependencies: (Yes/No)
9. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
