### PR TITLE
Set `--no-transfer-progress` option in maven builds for less verbose message

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
   push:
 
+env:
+  MVN_OPT: --no-transfer-progress
+
 jobs:
   build-extension:
     name: "Build Extensions"
@@ -46,7 +49,7 @@ jobs:
 
     - name: Build spark connector v2
       run: |
-        cd spark-doris-connector && mvn clean package \
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
           -Dspark.version=2.3.4 \
           -Dscala.version=2.11 \
           -Dthrift.binary=/usr/bin/thrift \
@@ -54,7 +57,7 @@ jobs:
 
     - name: Build spark connector v3
       run: |
-        cd spark-doris-connector && mvn clean package \
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
           -Dspark.version=3.1.2 \
           -Dscala.version=2.12 \
           -Dthrift.binary=/usr/bin/thrift \


### PR DESCRIPTION
# Proposed changes

- Set `--no-transfer-progress` option in CI maven builds for less verbose message 

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
