### PR TITLE
Upgrade `setup-java` action to v3 and change distribution to `temurin`

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -33,10 +33,11 @@ jobs:
       uses: actions/checkout@master
 
     - name: Setup java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
-        distribution: adopt
+        distribution: temurin
         java-version: '8'
+        cache: 'maven'
 
     - name: Setup thrift
       run: |


### PR DESCRIPTION
# Proposed changes

- upgrade `setup-java` action to v3-
- change distribution to  `temurin` , since `AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore.`
- enable caching for maven dependencies

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
