### PR TITLE
[Improve] Use streaming style on grouping, transforming and flushing RDD partitions

### DIFF
--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -57,9 +57,10 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
     if (Objects.nonNull(sinkTaskPartitionSize)) {
       resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
     }
-    // write for each partition
     resultRdd.map(row => {
-      (0 to row.size).map(i => row.get(i).asInstanceOf[AnyRef]).toList.asJava
+      (0 to row.size)
+        .map(i => row.get(i).asInstanceOf[AnyRef])
+        .toList.asJava
     }).foreachPartition(partition => {
       partition
         .grouped(batchSize)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -58,7 +58,7 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
       resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
     }
     resultRdd
-      .map(_.toSeq.map(a => a.asInstanceOf[AnyRef]).toList.asJava)
+      .map(_.toSeq.map(_.asInstanceOf[AnyRef]).toList.asJava)
       .foreachPartition(partition => {
         partition
           .grouped(batchSize)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -64,20 +64,20 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
     }).foreachPartition(partition => {
       partition
         .grouped(batchSize)
-        .foreach(batch => flush(batch.toList.asJava))
+        .foreach(batch => flush(batch))
     })
 
     /**
      * flush data to Doris and do retry when flush error
      *
      */
-    def flush(batch: util.List[util.List[Object]]): Unit = {
+    def flush(batch: Iterable[util.List[Object]]): Unit = {
       val loop = new Breaks
       var err: Exception = null
       loop.breakable {
         (1 to maxRetryTimes).foreach { i =>
           try {
-            dorisStreamLoader.loadV2(batch)
+            dorisStreamLoader.loadV2(batch.toList.asJava)
             Thread.sleep(batchInterValMs.longValue())
             loop.break()
           } catch {

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -18,12 +18,14 @@
 package org.apache.doris.spark.sql
 
 import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}
+import org.apache.doris.spark.sql.DorisWriterOptionKeys.maxRowCount
 import org.apache.doris.spark.{CachedDorisStreamLoadClient, DorisStreamLoad}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.slf4j.{Logger, LoggerFactory}
 
+import collection.JavaConverters._
 import java.io.IOException
 import java.util
 import java.util.Objects
@@ -33,7 +35,7 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[DorisStreamLoadSink].getName)
   @volatile private var latestBatchId = -1L
-  val maxRowCount: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
+  val batchSize: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
   val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_MAX_RETRIES, ConfigurationOptions.SINK_MAX_RETRIES_DEFAULT)
   val sinkTaskPartitionSize = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_TASK_PARTITION_SIZE)
   val sinkTaskUseRepartition = settings.getProperty(ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION, ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION_DEFAULT.toString).toBoolean
@@ -56,61 +58,42 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
       resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
     }
     // write for each partition
-    resultRdd.foreachPartition(partition => {
-      val rowsBuffer: util.List[util.List[Object]] = new util.ArrayList[util.List[Object]](maxRowCount)
-      partition.foreach(row => {
-        val line: util.List[Object] = new util.ArrayList[Object]()
-        for (i <- 0 until row.size) {
-          val field = row.get(i)
-          line.add(field.asInstanceOf[AnyRef])
-        }
-        rowsBuffer.add(line)
-        if (rowsBuffer.size > maxRowCount - 1) {
-          flush
-        }
-      })
-      // flush buffer
-      if (!rowsBuffer.isEmpty) {
-        flush
-      }
+    resultRdd.foreachPartition(partition =>
+      partition
+        .map(row => (0 to row.size).map(i => row.get(i).asInstanceOf[AnyRef]).toList.asJava)
+        .grouped(batchSize)
+        .foreach(batch => flush(batch.toList.asJava))
+    )
 
-      /**
-       * flush data to Doris and do retry when flush error
-       *
-       */
-      def flush(): Unit = {
-        val loop = new Breaks
-        var err: Exception = null
-        loop.breakable {
-
-          for (i <- 1 to maxRetryTimes) {
-            try {
-              dorisStreamLoader.loadV2(rowsBuffer)
-              rowsBuffer.clear()
-              Thread.sleep(batchInterValMs.longValue())
-              loop.break()
-            }
-            catch {
-              case e: Exception =>
-                try {
-                  logger.debug("Failed to load data on BE: {} node ", dorisStreamLoader.getLoadUrlStr)
-                  if (err == null) err = e
-                  Thread.sleep(1000 * i)
-                } catch {
-                  case ex: InterruptedException =>
-                    Thread.currentThread.interrupt()
-                    throw new IOException("unable to flush; interrupted while doing another attempt", ex)
-                }
-            }
+    /**
+     * flush data to Doris and do retry when flush error
+     *
+     */
+    def flush(batch: util.List[util.List[Object]]): Unit = {
+      val loop = new Breaks
+      var err: Exception = null
+      loop.breakable {
+        (1 to maxRetryTimes).foreach { i =>
+          try {
+            dorisStreamLoader.loadV2(batch)
+            Thread.sleep(batchInterValMs.longValue())
+            loop.break()
+          } catch {
+            case e: Exception =>
+              try {
+                logger.debug("Failed to load data on BE: {} node ", dorisStreamLoader.getLoadUrlStr)
+                if (err == null) err = e
+                Thread.sleep(1000 * i)
+              } catch {
+                case ex: InterruptedException =>
+                  Thread.currentThread.interrupt()
+                  throw new IOException("unable to flush; interrupted while doing another attempt", ex)
+              }
           }
-
-          if (!rowsBuffer.isEmpty) {
-            throw new IOException(s"Failed to load ${maxRowCount} batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", err)
-          }
+          throw new IOException(s"Failed to load $maxRowCount batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", err)
         }
-
       }
-    })
+    }
   }
 
   override def toString: String = "DorisStreamLoadSink"


### PR DESCRIPTION
# Proposed changes

- use streaming api on rdd portion in scala style, reducing reducant code and possible less memory footprint
- fix local property name `maxRowCount` to `batchSize`

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
