### PR TITLE
Provide 3.3.x option in build.sh

### DIFF
--- a/spark-doris-connector/build.sh
+++ b/spark-doris-connector/build.sh
@@ -142,7 +142,7 @@ selectScala() {
 
 selectSpark() {
   echo 'Spark-Doris-Connector supports multiple versions of spark. Which version do you need ?'
-  select spark in "2.3.x" "3.1.x" "3.2.x" "other"
+  select spark in "2.3.x" "3.1.x" "3.2.x" "3.3.x" "other"
   do
     case $spark in
       "2.3.x")
@@ -154,8 +154,11 @@ selectSpark() {
       "3.2.x")
         return 3
         ;;
-      "other")
+      "3.3.x")
         return 4
+        ;;
+      "other")
+        return 5
         ;;
     esac
   done
@@ -175,6 +178,8 @@ elif [ ${SparkVer} -eq 2 ]; then
 elif [ ${SparkVer} -eq 3 ]; then
     SPARK_VERSION="3.2.0"
 elif [ ${SparkVer} -eq 4 ]; then
+    SPARK_VERSION="3.3.2"
+elif [ ${SparkVer} -eq 5 ]; then
     # shellcheck disable=SC2162
     read -p 'Which spark version do you need? please input
     :' ver


### PR DESCRIPTION
# Proposed changes

- Provide 3.3.x option in build.sh

```
Spark-Doris-Connector supports multiple versions of spark. Which version do you need ?
1) 2.3.x
2) 3.1.x
3) 3.2.x
4) 3.3.x
5) other
```

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
