### PR TITLE
Introduce spotless maven plugin for linting Scala and Java code

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -33,5 +33,6 @@ header:
     - '**/*.log'
     - 'custom_env.sh.tpl'
     - '**/*.csv'
+    - '.scalafmt.conf'
 
   comment: on-failure

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,28 @@
+version = 3.7.1
+runner.dialect=scala212
+project.git=true
+
+align.preset = none
+align.openParenDefnSite = false
+align.openParenCallSite = false
+align.stripMargin = true
+align.tokens = []
+assumeStandardLibraryStripMargin = true
+danglingParentheses.preset = false
+docstrings.style = Asterisk
+docstrings.wrap = no
+importSelectors = singleLine
+indent.extendSite = 2
+literals.hexDigits = Upper
+maxColumn = 100
+newlines.source = keep
+newlines.topLevelStatementBlankLines = []
+optIn.configStyleArguments = false
+rewrite.imports.groups = [
+  ["javax?\\..*"],
+  ["scala\\..*"],
+  ["(?!org\\.apache\\.kyuubi\\.).*"],
+  ["org\\.apache\\.kyuubi\\..*"]
+]
+rewrite.imports.sort = scalastyle
+rewrite.rules = [Imports, SortModifiers]

--- a/spark-doris-connector/pom.xml
+++ b/spark-doris-connector/pom.xml
@@ -71,6 +71,9 @@
         <project.scm.id>github</project.scm.id>
         <netty.version>4.1.77.Final</netty.version>
         <fasterxml.jackson.version>2.13.3</fasterxml.jackson.version>
+        <maven.plugin.spotless.version>2.30.0</maven.plugin.spotless.version>
+        <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>
+        <spotless.scala.scalafmt.version>3.7.1</spotless.scala.scalafmt.version>
     </properties>
 
     <dependencies>
@@ -379,6 +382,45 @@
                         <phase>compile</phase>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${maven.plugin.spotless.version}</version>
+                <configuration>
+                    <upToDateChecking>
+                        <enabled>true</enabled>
+                    </upToDateChecking>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                        </includes>
+                        <googleJavaFormat>
+                            <version>${spotless.java.googlejavaformat.version}</version>
+                            <style>GOOGLE</style>
+                        </googleJavaFormat>
+                        <removeUnusedImports></removeUnusedImports>
+                    </java>
+                    <scala>
+                        <includes>
+                            <include>src/main/scala/**/*.scala</include>
+                            <include>src/test/scala/**/*.scala</include>
+                        </includes>
+                        <scalafmt>
+                            <version>${spotless.scala.scalafmt.version}</version>
+                            <scalaMajorVersion>${scala.version}</scalaMajorVersion>
+                            <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
+                        </scalafmt>
+                    </scala>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/CachedDorisStreamLoadClient.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/CachedDorisStreamLoadClient.java
@@ -22,42 +22,41 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
-import org.apache.doris.spark.cfg.SparkSettings;
-import org.apache.doris.spark.exception.DorisException;
-
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.doris.spark.cfg.SparkSettings;
+import org.apache.doris.spark.exception.DorisException;
 
-/**
- * a cached streamload client for each partition
- */
+/** a cached streamload client for each partition */
 public class CachedDorisStreamLoadClient {
-    private static final long cacheExpireTimeout = 30 * 60;
-    private static LoadingCache<SparkSettings, DorisStreamLoad> dorisStreamLoadLoadingCache;
+  private static final long cacheExpireTimeout = 30 * 60;
+  private static LoadingCache<SparkSettings, DorisStreamLoad> dorisStreamLoadLoadingCache;
 
-    static {
-        dorisStreamLoadLoadingCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheExpireTimeout, TimeUnit.SECONDS)
-                .removalListener(new RemovalListener<Object, Object>() {
-                    @Override
-                    public void onRemoval(RemovalNotification<Object, Object> removalNotification) {
-                        //do nothing
-                    }
+  static {
+    dorisStreamLoadLoadingCache =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(cacheExpireTimeout, TimeUnit.SECONDS)
+            .removalListener(
+                new RemovalListener<Object, Object>() {
+                  @Override
+                  public void onRemoval(RemovalNotification<Object, Object> removalNotification) {
+                    // do nothing
+                  }
                 })
-                .build(
-                        new CacheLoader<SparkSettings, DorisStreamLoad>() {
-                            @Override
-                            public DorisStreamLoad load(SparkSettings sparkSettings) throws IOException, DorisException {
-                                DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(sparkSettings);
-                                return dorisStreamLoad;
-                            }
-                        }
-                );
-    }
+            .build(
+                new CacheLoader<SparkSettings, DorisStreamLoad>() {
+                  @Override
+                  public DorisStreamLoad load(SparkSettings sparkSettings)
+                      throws IOException, DorisException {
+                    DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(sparkSettings);
+                    return dorisStreamLoad;
+                  }
+                });
+  }
 
-    public static DorisStreamLoad getOrCreate(SparkSettings settings) throws ExecutionException {
-        DorisStreamLoad dorisStreamLoad = dorisStreamLoadLoadingCache.get(settings);
-        return dorisStreamLoad;
-    }
+  public static DorisStreamLoad getOrCreate(SparkSettings settings) throws ExecutionException {
+    DorisStreamLoad dorisStreamLoad = dorisStreamLoadLoadingCache.get(settings);
+    return dorisStreamLoad;
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -21,6 +21,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.spark.cfg.ConfigurationOptions;
@@ -31,7 +38,6 @@ import org.apache.doris.spark.rest.RestService;
 import org.apache.doris.spark.rest.models.BackendV2;
 import org.apache.doris.spark.rest.models.RespContent;
 import org.apache.doris.spark.util.ListUtils;
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -44,280 +50,299 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-
-/**
- * DorisStreamLoad
- **/
+/** DorisStreamLoad */
 public class DorisStreamLoad implements Serializable {
-    private String FIELD_DELIMITER;
-    private String LINE_DELIMITER;
-    private String NULL_VALUE = "\\N";
+  private String FIELD_DELIMITER;
+  private String LINE_DELIMITER;
+  private String NULL_VALUE = "\\N";
 
-    private static final Logger LOG = LoggerFactory.getLogger(DorisStreamLoad.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DorisStreamLoad.class);
 
-    private final static List<String> DORIS_SUCCESS_STATUS = new ArrayList<>(Arrays.asList("Success", "Publish Timeout"));
-    private static String loadUrlPattern = "http://%s/api/%s/%s/_stream_load?";
-    private String user;
-    private String passwd;
-    private String loadUrlStr;
-    private String db;
-    private String tbl;
-    private String authEncoded;
-    private String columns;
-    private String[] dfColumns;
-    private String maxFilterRatio;
-    private Map<String, String> streamLoadProp;
-    private static final long cacheExpireTimeout = 4 * 60;
-    private LoadingCache<String, List<BackendV2.BackendRowV2>> cache;
-    private String fileType;
+  private static final List<String> DORIS_SUCCESS_STATUS =
+      new ArrayList<>(Arrays.asList("Success", "Publish Timeout"));
+  private static String loadUrlPattern = "http://%s/api/%s/%s/_stream_load?";
+  private String user;
+  private String passwd;
+  private String loadUrlStr;
+  private String db;
+  private String tbl;
+  private String authEncoded;
+  private String columns;
+  private String[] dfColumns;
+  private String maxFilterRatio;
+  private Map<String, String> streamLoadProp;
+  private static final long cacheExpireTimeout = 4 * 60;
+  private LoadingCache<String, List<BackendV2.BackendRowV2>> cache;
+  private String fileType;
 
-    public DorisStreamLoad(String hostPort, String db, String tbl, String user, String passwd) {
-        this.db = db;
-        this.tbl = tbl;
-        this.user = user;
-        this.passwd = passwd;
-        this.loadUrlStr = String.format(loadUrlPattern, hostPort, db, tbl);
-        this.authEncoded = getAuthEncoded(user, passwd);
+  public DorisStreamLoad(String hostPort, String db, String tbl, String user, String passwd) {
+    this.db = db;
+    this.tbl = tbl;
+    this.user = user;
+    this.passwd = passwd;
+    this.loadUrlStr = String.format(loadUrlPattern, hostPort, db, tbl);
+    this.authEncoded = getAuthEncoded(user, passwd);
+  }
+
+  public DorisStreamLoad(SparkSettings settings) throws IOException, DorisException {
+    String[] dbTable =
+        settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
+    this.db = dbTable[0];
+    this.tbl = dbTable[1];
+    this.user = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_USER);
+    this.passwd = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD);
+    this.authEncoded = getAuthEncoded(user, passwd);
+    this.columns = settings.getProperty(ConfigurationOptions.DORIS_WRITE_FIELDS);
+
+    this.maxFilterRatio = settings.getProperty(ConfigurationOptions.DORIS_MAX_FILTER_RATIO);
+    this.streamLoadProp = getStreamLoadProp(settings);
+    cache =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
+            .build(new BackendCacheLoader(settings));
+    fileType =
+        this.streamLoadProp.get("format") == null ? "csv" : this.streamLoadProp.get("format");
+    if (fileType.equals("csv")) {
+      FIELD_DELIMITER =
+          this.streamLoadProp.get("column_separator") == null
+              ? "\t"
+              : this.streamLoadProp.get("column_separator");
+      LINE_DELIMITER =
+          this.streamLoadProp.get("line_delimiter") == null
+              ? "\n"
+              : this.streamLoadProp.get("line_delimiter");
+    }
+  }
+
+  public DorisStreamLoad(SparkSettings settings, String[] dfColumns)
+      throws IOException, DorisException {
+    String[] dbTable =
+        settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
+    this.db = dbTable[0];
+    this.tbl = dbTable[1];
+    this.user = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_USER);
+    this.passwd = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD);
+
+    this.authEncoded = getAuthEncoded(user, passwd);
+    this.columns = settings.getProperty(ConfigurationOptions.DORIS_WRITE_FIELDS);
+    this.dfColumns = dfColumns;
+
+    this.maxFilterRatio = settings.getProperty(ConfigurationOptions.DORIS_MAX_FILTER_RATIO);
+    this.streamLoadProp = getStreamLoadProp(settings);
+    cache =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
+            .build(new BackendCacheLoader(settings));
+    fileType =
+        this.streamLoadProp.get("format") == null ? "csv" : this.streamLoadProp.get("format");
+    if ("csv".equals(fileType)) {
+      FIELD_DELIMITER =
+          this.streamLoadProp.get("column_separator") == null
+              ? "\t"
+              : this.streamLoadProp.get("column_separator");
+      LINE_DELIMITER =
+          this.streamLoadProp.get("line_delimiter") == null
+              ? "\n"
+              : this.streamLoadProp.get("line_delimiter");
+    }
+  }
+
+  public String getLoadUrlStr() {
+    if (StringUtils.isEmpty(loadUrlStr)) {
+      return "";
+    }
+    return loadUrlStr;
+  }
+
+  private CloseableHttpClient getHttpClient() {
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().disableRedirectHandling();
+    return httpClientBuilder.build();
+  }
+
+  private HttpPut getHttpPut(String label, String loadUrlStr) {
+    HttpPut httpPut = new HttpPut(loadUrlStr);
+    httpPut.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + authEncoded);
+    httpPut.setHeader(HttpHeaders.EXPECT, "100-continue");
+    httpPut.setHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
+    httpPut.setHeader("label", label);
+    if (StringUtils.isNotBlank(columns)) {
+      httpPut.setHeader("columns", columns);
+    }
+    if (StringUtils.isNotBlank(maxFilterRatio)) {
+      httpPut.setHeader("max_filter_ratio", maxFilterRatio);
+    }
+    if (MapUtils.isNotEmpty(streamLoadProp)) {
+      streamLoadProp.entrySet().stream()
+          .filter(entry -> !"read_json_by_line".equals(entry.getKey()))
+          .forEach(entry -> httpPut.setHeader(entry.getKey(), entry.getValue()));
+    }
+    if (fileType.equals("json")) {
+      httpPut.setHeader("strip_outer_array", "true");
+    }
+    return httpPut;
+  }
+
+  public static class LoadResponse {
+    public int status;
+    public String respMsg;
+    public String respContent;
+
+    public LoadResponse(int status, String respMsg, String respContent) {
+      this.status = status;
+      this.respMsg = respMsg;
+      this.respContent = respContent;
     }
 
-    public DorisStreamLoad(SparkSettings settings) throws IOException, DorisException {
-        String[] dbTable = settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
-        this.db = dbTable[0];
-        this.tbl = dbTable[1];
-        this.user = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_USER);
-        this.passwd = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD);
-        this.authEncoded = getAuthEncoded(user, passwd);
-        this.columns = settings.getProperty(ConfigurationOptions.DORIS_WRITE_FIELDS);
-
-        this.maxFilterRatio = settings.getProperty(ConfigurationOptions.DORIS_MAX_FILTER_RATIO);
-        this.streamLoadProp = getStreamLoadProp(settings);
-        cache = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
-                .build(new BackendCacheLoader(settings));
-        fileType = this.streamLoadProp.get("format") == null ? "csv" : this.streamLoadProp.get("format");
-        if (fileType.equals("csv")){
-            FIELD_DELIMITER = this.streamLoadProp.get("column_separator") == null ? "\t" : this.streamLoadProp.get("column_separator");
-            LINE_DELIMITER = this.streamLoadProp.get("line_delimiter") == null ? "\n" : this.streamLoadProp.get("line_delimiter");
-        }
+    @Override
+    public String toString() {
+      return "status: " + status + ", resp msg: " + respMsg + ", resp content: " + respContent;
     }
+  }
 
-    public DorisStreamLoad(SparkSettings settings, String[] dfColumns) throws IOException, DorisException {
-        String[] dbTable = settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
-        this.db = dbTable[0];
-        this.tbl = dbTable[1];
-        this.user = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_USER);
-        this.passwd = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD);
+  public String listToString(List<List<Object>> rows) {
+    return rows.stream()
+        .map(
+            row ->
+                row.stream()
+                    .map(field -> (field == null) ? NULL_VALUE : field.toString())
+                    .collect(Collectors.joining(FIELD_DELIMITER)))
+        .collect(Collectors.joining(LINE_DELIMITER));
+  }
 
-
-        this.authEncoded = getAuthEncoded(user, passwd);
-        this.columns = settings.getProperty(ConfigurationOptions.DORIS_WRITE_FIELDS);
-        this.dfColumns = dfColumns;
-
-        this.maxFilterRatio = settings.getProperty(ConfigurationOptions.DORIS_MAX_FILTER_RATIO);
-        this.streamLoadProp = getStreamLoadProp(settings);
-        cache = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
-                .build(new BackendCacheLoader(settings));
-        fileType = this.streamLoadProp.get("format") == null ? "csv" : this.streamLoadProp.get("format");
-        if ("csv".equals(fileType)) {
-            FIELD_DELIMITER = this.streamLoadProp.get("column_separator") == null ? "\t" : this.streamLoadProp.get("column_separator");
-            LINE_DELIMITER = this.streamLoadProp.get("line_delimiter") == null ? "\n" : this.streamLoadProp.get("line_delimiter");
-        }
-    }
-
-    public String getLoadUrlStr() {
-        if (StringUtils.isEmpty(loadUrlStr)) {
-            return "";
-        }
-        return loadUrlStr;
-    }
-    private CloseableHttpClient getHttpClient() {
-        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
-                .disableRedirectHandling();
-        return httpClientBuilder.build();
-    }
-
-    private HttpPut getHttpPut(String label, String loadUrlStr) {
-        HttpPut httpPut = new HttpPut(loadUrlStr);
-        httpPut.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + authEncoded);
-        httpPut.setHeader(HttpHeaders.EXPECT, "100-continue");
-        httpPut.setHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
-        httpPut.setHeader("label", label);
-        if (StringUtils.isNotBlank(columns)) {
-            httpPut.setHeader("columns", columns);
-        }
-        if (StringUtils.isNotBlank(maxFilterRatio)) {
-            httpPut.setHeader("max_filter_ratio", maxFilterRatio);
-        }
-        if (MapUtils.isNotEmpty(streamLoadProp)) {
-            streamLoadProp.entrySet().stream()
-                    .filter(entry -> !"read_json_by_line".equals(entry.getKey()))
-                    .forEach(entry -> httpPut.setHeader(entry.getKey(), entry.getValue()));
-        }
-        if (fileType.equals("json")) {
-            httpPut.setHeader("strip_outer_array", "true");
-        }
-        return httpPut;
-    }
-
-    public static class LoadResponse {
-        public int status;
-        public String respMsg;
-        public String respContent;
-
-        public LoadResponse(int status, String respMsg, String respContent) {
-            this.status = status;
-            this.respMsg = respMsg;
-            this.respContent = respContent;
-        }
-
-        @Override
-        public String toString() {
-            return "status: " + status +
-                    ", resp msg: " + respMsg +
-                    ", resp content: " + respContent;
-        }
-    }
-
-    public String listToString(List<List<Object>> rows) {
-        return rows.stream().map(row ->
-                row.stream().map(field ->
-                        (field == null) ? NULL_VALUE : field.toString()
-                ).collect(Collectors.joining(FIELD_DELIMITER))
-        ).collect(Collectors.joining(LINE_DELIMITER));
-    }
-
-
-    public void loadV2(List<List<Object>> rows) throws StreamLoadException, JsonProcessingException {
-        if (fileType.equals("csv")) {
-            load(listToString(rows));
-        } else if(fileType.equals("json")) {
-            List<Map<Object, Object>> dataList = new ArrayList<>();
-            try {
-                for (List<Object> row : rows) {
-                    Map<Object, Object> dataMap = new HashMap<>();
-                    if (dfColumns.length == row.size()) {
-                        for (int i = 0; i < dfColumns.length; i++) {
-                            dataMap.put(dfColumns[i], row.get(i));
-                        }
-                    }
-                    dataList.add(dataMap);
-                }
-            } catch (Exception e) {
-                throw new StreamLoadException("The number of configured columns does not match the number of data columns.");
+  public void loadV2(List<List<Object>> rows) throws StreamLoadException, JsonProcessingException {
+    if (fileType.equals("csv")) {
+      load(listToString(rows));
+    } else if (fileType.equals("json")) {
+      List<Map<Object, Object>> dataList = new ArrayList<>();
+      try {
+        for (List<Object> row : rows) {
+          Map<Object, Object> dataMap = new HashMap<>();
+          if (dfColumns.length == row.size()) {
+            for (int i = 0; i < dfColumns.length; i++) {
+              dataMap.put(dfColumns[i], row.get(i));
             }
-            // splits large collections to normal collection to avoid the "Requested array size exceeds VM limit" exception
-            List<String> serializedList = ListUtils.getSerializedList(dataList);
-            for (String serializedRows : serializedList) {
-                load(serializedRows);
-            }
-        } else {
-            throw new StreamLoadException(String.format("Unsupported file format in stream load: %s.", fileType));
+          }
+          dataList.add(dataMap);
         }
+      } catch (Exception e) {
+        throw new StreamLoadException(
+            "The number of configured columns does not match the number of data columns.");
+      }
+      // splits large collections to normal collection to avoid the "Requested array size exceeds VM
+      // limit" exception
+      List<String> serializedList = ListUtils.getSerializedList(dataList);
+      for (String serializedRows : serializedList) {
+        load(serializedRows);
+      }
+    } else {
+      throw new StreamLoadException(
+          String.format("Unsupported file format in stream load: %s.", fileType));
+    }
+  }
+
+  public void load(String value) throws StreamLoadException {
+    LoadResponse loadResponse = loadBatch(value);
+    if (loadResponse.status != HttpStatus.SC_OK) {
+      LOG.info("Streamload Response HTTP Status Error:{}", loadResponse);
+      throw new StreamLoadException("stream load error: " + loadResponse.respContent);
+    } else {
+      ObjectMapper obj = new ObjectMapper();
+      try {
+        RespContent respContent = obj.readValue(loadResponse.respContent, RespContent.class);
+        if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
+          LOG.error("Streamload Response RES STATUS Error:{}", loadResponse);
+          throw new StreamLoadException("stream load error: " + loadResponse);
+        }
+        LOG.info("Streamload Response:{}", loadResponse);
+      } catch (IOException e) {
+        throw new StreamLoadException(e);
+      }
+    }
+  }
+
+  private LoadResponse loadBatch(String value) {
+    Calendar calendar = Calendar.getInstance();
+    String label =
+        String.format(
+            "spark_streamload_%s%02d%02d_%02d%02d%02d_%s",
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH) + 1,
+            calendar.get(Calendar.DAY_OF_MONTH),
+            calendar.get(Calendar.HOUR_OF_DAY),
+            calendar.get(Calendar.MINUTE),
+            calendar.get(Calendar.SECOND),
+            UUID.randomUUID().toString().replaceAll("-", ""));
+
+    int responseHttpStatus = -1;
+    try (CloseableHttpClient httpClient = getHttpClient()) {
+      String loadUrlStr = String.format(loadUrlPattern, getBackend(), db, tbl);
+      LOG.debug("Streamload Request:{} ,Body:{}", loadUrlStr, value);
+      // only to record the BE node in case of an exception
+      this.loadUrlStr = loadUrlStr;
+
+      HttpPut httpPut = getHttpPut(label, loadUrlStr);
+      httpPut.setEntity(new StringEntity(value, StandardCharsets.UTF_8));
+      HttpResponse httpResponse = httpClient.execute(httpPut);
+      responseHttpStatus = httpResponse.getStatusLine().getStatusCode();
+      String respMsg = httpResponse.getStatusLine().getReasonPhrase();
+      String response =
+          EntityUtils.toString(
+              new BufferedHttpEntity(httpResponse.getEntity()), StandardCharsets.UTF_8);
+      return new LoadResponse(responseHttpStatus, respMsg, response);
+    } catch (IOException e) {
+      e.printStackTrace();
+      String err =
+          "http request exception,load url : "
+              + loadUrlStr
+              + ",failed to execute spark streamload with label: "
+              + label;
+      LOG.warn(err, e);
+      return new LoadResponse(responseHttpStatus, e.getMessage(), err);
+    }
+  }
+
+  public Map<String, String> getStreamLoadProp(SparkSettings sparkSettings) {
+    Map<String, String> streamLoadPropMap = new HashMap<>();
+    Properties properties = sparkSettings.asProperties();
+    for (String key : properties.stringPropertyNames()) {
+      if (key.contains(ConfigurationOptions.STREAM_LOAD_PROP_PREFIX)) {
+        String subKey = key.substring(ConfigurationOptions.STREAM_LOAD_PROP_PREFIX.length());
+        streamLoadPropMap.put(subKey, properties.getProperty(key));
+      }
+    }
+    return streamLoadPropMap;
+  }
+
+  private String getBackend() {
+    try {
+      // get backends from cache
+      List<BackendV2.BackendRowV2> backends = cache.get("backends");
+      Collections.shuffle(backends);
+      BackendV2.BackendRowV2 backend = backends.get(0);
+      return backend.getIp() + ":" + backend.getHttpPort();
+    } catch (ExecutionException e) {
+      throw new RuntimeException("get backends info fail", e);
+    }
+  }
+
+  private static String getAuthEncoded(String user, String passwd) {
+    String raw = String.format("%s:%s", user, passwd);
+    return Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /** serializable be cache loader */
+  private static class BackendCacheLoader extends CacheLoader<String, List<BackendV2.BackendRowV2>>
+      implements Serializable {
+
+    private final SparkSettings settings;
+
+    public BackendCacheLoader(SparkSettings settings) {
+      this.settings = settings;
     }
 
-    public void load(String value) throws StreamLoadException {
-        LoadResponse loadResponse = loadBatch(value);
-        if (loadResponse.status != HttpStatus.SC_OK) {
-            LOG.info("Streamload Response HTTP Status Error:{}", loadResponse);
-            throw new StreamLoadException("stream load error: " + loadResponse.respContent);
-        } else {
-            ObjectMapper obj = new ObjectMapper();
-            try {
-                RespContent respContent = obj.readValue(loadResponse.respContent, RespContent.class);
-                if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
-                    LOG.error("Streamload Response RES STATUS Error:{}", loadResponse);
-                    throw new StreamLoadException("stream load error: " + loadResponse);
-                }
-                LOG.info("Streamload Response:{}", loadResponse);
-            } catch (IOException e) {
-                throw new StreamLoadException(e);
-            }
-        }
+    @Override
+    public List<BackendV2.BackendRowV2> load(String key) throws Exception {
+      return RestService.getBackendRows(settings, LOG);
     }
-
-    private LoadResponse loadBatch(String value) {
-        Calendar calendar = Calendar.getInstance();
-        String label = String.format("spark_streamload_%s%02d%02d_%02d%02d%02d_%s",
-                calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH),
-                calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND),
-                UUID.randomUUID().toString().replaceAll("-", ""));
-
-        int responseHttpStatus = -1;
-        try (CloseableHttpClient httpClient = getHttpClient()) {
-            String loadUrlStr = String.format(loadUrlPattern, getBackend(), db, tbl);
-            LOG.debug("Streamload Request:{} ,Body:{}", loadUrlStr, value);
-            //only to record the BE node in case of an exception
-            this.loadUrlStr = loadUrlStr;
-
-            HttpPut httpPut = getHttpPut(label, loadUrlStr);
-            httpPut.setEntity(new StringEntity(value, StandardCharsets.UTF_8));
-            HttpResponse httpResponse = httpClient.execute(httpPut);
-            responseHttpStatus = httpResponse.getStatusLine().getStatusCode();
-            String respMsg = httpResponse.getStatusLine().getReasonPhrase();
-            String response = EntityUtils.toString(new BufferedHttpEntity(httpResponse.getEntity()), StandardCharsets.UTF_8);
-            return new LoadResponse(responseHttpStatus, respMsg, response);
-        } catch (IOException e) {
-            e.printStackTrace();
-            String err = "http request exception,load url : " + loadUrlStr + ",failed to execute spark streamload with label: " + label;
-            LOG.warn(err, e);
-            return new LoadResponse(responseHttpStatus, e.getMessage(), err);
-        }
-    }
-
-    public Map<String, String> getStreamLoadProp(SparkSettings sparkSettings) {
-        Map<String, String> streamLoadPropMap = new HashMap<>();
-        Properties properties = sparkSettings.asProperties();
-        for (String key : properties.stringPropertyNames()) {
-            if (key.contains(ConfigurationOptions.STREAM_LOAD_PROP_PREFIX)) {
-                String subKey = key.substring(ConfigurationOptions.STREAM_LOAD_PROP_PREFIX.length());
-                streamLoadPropMap.put(subKey, properties.getProperty(key));
-            }
-        }
-        return streamLoadPropMap;
-    }
-
-    private String getBackend() {
-        try {
-            //get backends from cache
-            List<BackendV2.BackendRowV2> backends = cache.get("backends");
-            Collections.shuffle(backends);
-            BackendV2.BackendRowV2 backend = backends.get(0);
-            return backend.getIp() + ":" + backend.getHttpPort();
-        } catch (ExecutionException e) {
-            throw new RuntimeException("get backends info fail", e);
-        }
-    }
-
-    private static String getAuthEncoded(String user, String passwd) {
-        String raw = String.format("%s:%s", user, passwd);
-        return Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
-    }
-
-    /**
-     * serializable be cache loader
-     */
-    private static class BackendCacheLoader extends CacheLoader<String, List<BackendV2.BackendRowV2>> implements Serializable {
-
-        private final SparkSettings settings;
-
-        public BackendCacheLoader(SparkSettings settings) {
-            this.settings = settings;
-        }
-
-        @Override
-        public List<BackendV2.BackendRowV2> load(String key) throws Exception {
-            return RestService.getBackendRows(settings, LOG);
-        }
-
-    }
-
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/backend/BackendClient.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/backend/BackendClient.java
@@ -18,12 +18,12 @@
 package org.apache.doris.spark.backend;
 
 import org.apache.doris.spark.cfg.ConfigurationOptions;
+import org.apache.doris.spark.cfg.Settings;
 import org.apache.doris.spark.exception.ConnectedFailedException;
 import org.apache.doris.spark.exception.DorisException;
 import org.apache.doris.spark.exception.DorisInternalException;
-import org.apache.doris.spark.util.ErrorMessages;
-import org.apache.doris.spark.cfg.Settings;
 import org.apache.doris.spark.serialization.Routing;
+import org.apache.doris.spark.util.ErrorMessages;
 import org.apache.doris.thrift.TDorisExternalService;
 import org.apache.doris.thrift.TScanBatchResult;
 import org.apache.doris.thrift.TScanCloseParams;
@@ -41,187 +41,211 @@ import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Client to request Doris BE
- */
+/** Client to request Doris BE */
 public class BackendClient {
-    private final static Logger logger = LoggerFactory.getLogger(BackendClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(BackendClient.class);
 
-    private Routing routing;
+  private Routing routing;
 
-    private TDorisExternalService.Client client;
-    private TTransport transport;
+  private TDorisExternalService.Client client;
+  private TTransport transport;
 
-    private boolean isConnected = false;
-    private final int retries;
-    private final int socketTimeout;
-    private final int connectTimeout;
+  private boolean isConnected = false;
+  private final int retries;
+  private final int socketTimeout;
+  private final int connectTimeout;
 
-    public BackendClient(Routing routing, Settings settings) throws ConnectedFailedException {
-        this.routing = routing;
-        this.connectTimeout = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS,
-                ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT);
-        this.socketTimeout = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS,
-                ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT);
-        this.retries = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES,
-                ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT);
-        logger.trace("connect timeout set to '{}'. socket timeout set to '{}'. retries set to '{}'.",
-                this.connectTimeout, this.socketTimeout, this.retries);
+  public BackendClient(Routing routing, Settings settings) throws ConnectedFailedException {
+    this.routing = routing;
+    this.connectTimeout =
+        settings.getIntegerProperty(
+            ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS,
+            ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT);
+    this.socketTimeout =
+        settings.getIntegerProperty(
+            ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS,
+            ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT);
+    this.retries =
+        settings.getIntegerProperty(
+            ConfigurationOptions.DORIS_REQUEST_RETRIES,
+            ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT);
+    logger.trace(
+        "connect timeout set to '{}'. socket timeout set to '{}'. retries set to '{}'.",
+        this.connectTimeout,
+        this.socketTimeout,
+        this.retries);
+    open();
+  }
+
+  private void open() throws ConnectedFailedException {
+    logger.debug("Open client to Doris BE '{}'.", routing);
+    TException ex = null;
+    for (int attempt = 0; !isConnected && attempt < retries; ++attempt) {
+      logger.debug("Attempt {} to connect {}.", attempt, routing);
+      TBinaryProtocol.Factory factory = new TBinaryProtocol.Factory();
+      transport = new TSocket(routing.getHost(), routing.getPort(), socketTimeout, connectTimeout);
+      TProtocol protocol = factory.getProtocol(transport);
+      client = new TDorisExternalService.Client(protocol);
+      try {
+        logger.trace("Connect status before open transport to {} is '{}'.", routing, isConnected);
+        if (!transport.isOpen()) {
+          transport.open();
+          isConnected = true;
+        }
+      } catch (TTransportException e) {
+        logger.warn(ErrorMessages.CONNECT_FAILED_MESSAGE, routing, e);
+        ex = e;
+      }
+      if (isConnected) {
+        logger.info("Success connect to {}.", routing);
+        break;
+      }
+    }
+    if (!isConnected) {
+      logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
+      throw new ConnectedFailedException(routing.toString(), ex);
+    }
+  }
+
+  private void close() {
+    logger.trace("Connect status before close with '{}' is '{}'.", routing, isConnected);
+    isConnected = false;
+    if (null != client) {
+      client = null;
+    }
+    if ((transport != null) && transport.isOpen()) {
+      transport.close();
+      logger.info("Closed a connection to {}.", routing);
+    }
+  }
+
+  /**
+   * Open a scanner for reading Doris data.
+   *
+   * @param openParams thrift struct to required by request
+   * @return scan open result
+   * @throws ConnectedFailedException throw if cannot connect to Doris BE
+   */
+  public TScanOpenResult openScanner(TScanOpenParams openParams) throws ConnectedFailedException {
+    logger.debug("OpenScanner to '{}', parameter is '{}'.", routing, openParams);
+    if (!isConnected) {
+      open();
+    }
+    TException ex = null;
+    for (int attempt = 0; attempt < retries; ++attempt) {
+      logger.debug("Attempt {} to openScanner {}.", attempt, routing);
+      try {
+        TScanOpenResult result = client.openScanner(openParams);
+        if (result == null) {
+          logger.warn("Open scanner result from {} is null.", routing);
+          continue;
+        }
+        if (!TStatusCode.OK.equals(result.getStatus().getStatusCode())) {
+          logger.warn(
+              "The status of open scanner result from {} is '{}', error message is: {}.",
+              routing,
+              result.getStatus().getStatusCode(),
+              result.getStatus().getErrorMsgs());
+          continue;
+        }
+        return result;
+      } catch (TException e) {
+        logger.warn("Open scanner from {} failed.", routing, e);
+        ex = e;
+      }
+    }
+    logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
+    throw new ConnectedFailedException(routing.toString(), ex);
+  }
+
+  /**
+   * get next row batch from Doris BE
+   *
+   * @param nextBatchParams thrift struct to required by request
+   * @return scan batch result
+   * @throws ConnectedFailedException throw if cannot connect to Doris BE
+   */
+  public TScanBatchResult getNext(TScanNextBatchParams nextBatchParams) throws DorisException {
+    logger.debug("GetNext to '{}', parameter is '{}'.", routing, nextBatchParams);
+    if (!isConnected) {
+      open();
+    }
+    TException ex = null;
+    TScanBatchResult result = null;
+    for (int attempt = 0; attempt < retries; ++attempt) {
+      logger.debug("Attempt {} to getNext {}.", attempt, routing);
+      try {
+        result = client.getNext(nextBatchParams);
+        if (result == null) {
+          logger.warn("GetNext result from {} is null.", routing);
+          continue;
+        }
+        if (!TStatusCode.OK.equals(result.getStatus().getStatusCode())) {
+          logger.warn(
+              "The status of get next result from {} is '{}', error message is: {}.",
+              routing,
+              result.getStatus().getStatusCode(),
+              result.getStatus().getErrorMsgs());
+          continue;
+        }
+        return result;
+      } catch (TException e) {
+        logger.warn("Get next from {} failed.", routing, e);
+        ex = e;
+      }
+    }
+    if (result != null && (TStatusCode.OK != (result.getStatus().getStatusCode()))) {
+      logger.error(
+          ErrorMessages.DORIS_INTERNAL_FAIL_MESSAGE,
+          routing,
+          result.getStatus().getStatusCode(),
+          result.getStatus().getErrorMsgs());
+      throw new DorisInternalException(
+          routing.toString(),
+          result.getStatus().getStatusCode(),
+          result.getStatus().getErrorMsgs());
+    }
+    logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
+    throw new ConnectedFailedException(routing.toString(), ex);
+  }
+
+  /**
+   * close an scanner.
+   *
+   * @param closeParams thrift struct to required by request
+   */
+  public void closeScanner(TScanCloseParams closeParams) {
+    logger.debug("CloseScanner to '{}', parameter is '{}'.", routing, closeParams);
+    if (!isConnected) {
+      try {
         open();
+      } catch (ConnectedFailedException e) {
+        logger.warn("Cannot connect to Doris BE {} when close scanner.", routing);
+        return;
+      }
     }
-
-    private void open() throws ConnectedFailedException {
-        logger.debug("Open client to Doris BE '{}'.", routing);
-        TException ex = null;
-        for (int attempt = 0; !isConnected && attempt < retries; ++attempt) {
-            logger.debug("Attempt {} to connect {}.", attempt, routing);
-            TBinaryProtocol.Factory factory = new TBinaryProtocol.Factory();
-            transport = new TSocket(routing.getHost(), routing.getPort(), socketTimeout, connectTimeout);
-            TProtocol protocol = factory.getProtocol(transport);
-            client = new TDorisExternalService.Client(protocol);
-            try {
-                logger.trace("Connect status before open transport to {} is '{}'.", routing, isConnected);
-                if (!transport.isOpen()) {
-                    transport.open();
-                    isConnected = true;
-                }
-            } catch (TTransportException e) {
-                logger.warn(ErrorMessages.CONNECT_FAILED_MESSAGE, routing, e);
-                ex = e;
-            }
-            if (isConnected) {
-                logger.info("Success connect to {}.", routing);
-                break;
-            }
+    for (int attempt = 0; attempt < retries; ++attempt) {
+      logger.debug("Attempt {} to closeScanner {}.", attempt, routing);
+      try {
+        TScanCloseResult result = client.closeScanner(closeParams);
+        if (result == null) {
+          logger.warn("CloseScanner result from {} is null.", routing);
+          continue;
         }
-        if (!isConnected) {
-            logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
-            throw new ConnectedFailedException(routing.toString(), ex);
+        if (!TStatusCode.OK.equals(result.getStatus().getStatusCode())) {
+          logger.warn(
+              "The status of get next result from {} is '{}', error message is: {}.",
+              routing,
+              result.getStatus().getStatusCode(),
+              result.getStatus().getErrorMsgs());
+          continue;
         }
+        break;
+      } catch (TException e) {
+        logger.warn("Close scanner from {} failed.", routing, e);
+      }
     }
-
-    private void close() {
-        logger.trace("Connect status before close with '{}' is '{}'.", routing, isConnected);
-        isConnected = false;
-        if (null != client) {
-            client = null;
-        }
-        if ((transport != null) && transport.isOpen()) {
-            transport.close();
-            logger.info("Closed a connection to {}.", routing);
-        }
-    }
-
-    /**
-     * Open a scanner for reading Doris data.
-     * @param openParams thrift struct to required by request
-     * @return scan open result
-     * @throws ConnectedFailedException throw if cannot connect to Doris BE
-     */
-    public TScanOpenResult openScanner(TScanOpenParams openParams) throws ConnectedFailedException {
-        logger.debug("OpenScanner to '{}', parameter is '{}'.", routing, openParams);
-        if (!isConnected) {
-            open();
-        }
-        TException ex = null;
-        for (int attempt = 0; attempt < retries; ++attempt) {
-            logger.debug("Attempt {} to openScanner {}.", attempt, routing);
-            try {
-                TScanOpenResult result = client.openScanner(openParams);
-                if (result == null) {
-                    logger.warn("Open scanner result from {} is null.", routing);
-                    continue;
-                }
-                if (!TStatusCode.OK.equals(result.getStatus().getStatusCode())) {
-                    logger.warn("The status of open scanner result from {} is '{}', error message is: {}.",
-                            routing, result.getStatus().getStatusCode(), result.getStatus().getErrorMsgs());
-                    continue;
-                }
-                return result;
-            } catch (TException e) {
-                logger.warn("Open scanner from {} failed.", routing, e);
-                ex = e;
-            }
-        }
-        logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
-        throw new ConnectedFailedException(routing.toString(), ex);
-    }
-
-    /**
-     * get next row batch from Doris BE
-     * @param nextBatchParams thrift struct to required by request
-     * @return scan batch result
-     * @throws ConnectedFailedException throw if cannot connect to Doris BE
-     */
-    public TScanBatchResult getNext(TScanNextBatchParams nextBatchParams) throws DorisException {
-        logger.debug("GetNext to '{}', parameter is '{}'.", routing, nextBatchParams);
-        if (!isConnected) {
-            open();
-        }
-        TException ex = null;
-        TScanBatchResult result = null;
-        for (int attempt = 0; attempt < retries; ++attempt) {
-            logger.debug("Attempt {} to getNext {}.", attempt, routing);
-            try {
-                result  = client.getNext(nextBatchParams);
-                if (result == null) {
-                    logger.warn("GetNext result from {} is null.", routing);
-                    continue;
-                }
-                if (!TStatusCode.OK.equals(result.getStatus().getStatusCode())) {
-                    logger.warn("The status of get next result from {} is '{}', error message is: {}.",
-                            routing, result.getStatus().getStatusCode(), result.getStatus().getErrorMsgs());
-                    continue;
-                }
-                return result;
-            } catch (TException e) {
-                logger.warn("Get next from {} failed.", routing, e);
-                ex = e;
-            }
-        }
-        if (result != null && (TStatusCode.OK != (result.getStatus().getStatusCode()))) {
-            logger.error(ErrorMessages.DORIS_INTERNAL_FAIL_MESSAGE, routing, result.getStatus().getStatusCode(),
-                    result.getStatus().getErrorMsgs());
-            throw new DorisInternalException(routing.toString(), result.getStatus().getStatusCode(),
-                    result.getStatus().getErrorMsgs());
-        }
-        logger.error(ErrorMessages.CONNECT_FAILED_MESSAGE, routing);
-        throw new ConnectedFailedException(routing.toString(), ex);
-    }
-
-    /**
-     * close an scanner.
-     * @param closeParams thrift struct to required by request
-     */
-    public void closeScanner(TScanCloseParams closeParams) {
-        logger.debug("CloseScanner to '{}', parameter is '{}'.", routing, closeParams);
-        if (!isConnected) {
-            try {
-                open();
-            } catch (ConnectedFailedException e) {
-                logger.warn("Cannot connect to Doris BE {} when close scanner.", routing);
-                return;
-            }
-        }
-        for (int attempt = 0; attempt < retries; ++attempt) {
-            logger.debug("Attempt {} to closeScanner {}.", attempt, routing);
-            try {
-                TScanCloseResult result = client.closeScanner(closeParams);
-                if (result == null) {
-                    logger.warn("CloseScanner result from {} is null.", routing);
-                    continue;
-                }
-                if (!TStatusCode.OK.equals(result.getStatus().getStatusCode())) {
-                    logger.warn("The status of get next result from {} is '{}', error message is: {}.",
-                            routing, result.getStatus().getStatusCode(), result.getStatus().getErrorMsgs());
-                    continue;
-                }
-                break;
-            } catch (TException e) {
-                logger.warn("Close scanner from {} failed.", routing, e);
-            }
-        }
-        logger.info("CloseScanner to Doris BE '{}' success.", routing);
-        close();
-    }
+    logger.info("CloseScanner to Doris BE '{}' success.", routing);
+    close();
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -18,76 +18,77 @@
 package org.apache.doris.spark.cfg;
 
 public interface ConfigurationOptions {
-    // doris fe node address
-    String DORIS_FENODES = "doris.fenodes";
+  // doris fe node address
+  String DORIS_FENODES = "doris.fenodes";
 
-    String DORIS_DEFAULT_CLUSTER = "default_cluster";
+  String DORIS_DEFAULT_CLUSTER = "default_cluster";
 
-    String TABLE_IDENTIFIER = "table.identifier";
-    String DORIS_TABLE_IDENTIFIER = "doris.table.identifier";
-    String DORIS_READ_FIELD = "doris.read.field";
-    String DORIS_FILTER_QUERY = "doris.filter.query";
-    String DORIS_FILTER_QUERY_IN_MAX_COUNT = "doris.filter.query.in.max.count";
-    int DORIS_FILTER_QUERY_IN_VALUE_UPPER_LIMIT = 10000;
+  String TABLE_IDENTIFIER = "table.identifier";
+  String DORIS_TABLE_IDENTIFIER = "doris.table.identifier";
+  String DORIS_READ_FIELD = "doris.read.field";
+  String DORIS_FILTER_QUERY = "doris.filter.query";
+  String DORIS_FILTER_QUERY_IN_MAX_COUNT = "doris.filter.query.in.max.count";
+  int DORIS_FILTER_QUERY_IN_VALUE_UPPER_LIMIT = 10000;
 
-    String DORIS_USER = "doris.user";
-    String DORIS_REQUEST_AUTH_USER = "doris.request.auth.user";
-    // use password to save doris.request.auth.password
-    // reuse credentials mask method in spark ExternalCatalogUtils#maskCredentials
-    String DORIS_PASSWORD = "doris.password";
-    String DORIS_REQUEST_AUTH_PASSWORD = "doris.request.auth.password";
+  String DORIS_USER = "doris.user";
+  String DORIS_REQUEST_AUTH_USER = "doris.request.auth.user";
+  // use password to save doris.request.auth.password
+  // reuse credentials mask method in spark ExternalCatalogUtils#maskCredentials
+  String DORIS_PASSWORD = "doris.password";
+  String DORIS_REQUEST_AUTH_PASSWORD = "doris.request.auth.password";
 
-    String DORIS_REQUEST_RETRIES = "doris.request.retries";
-    String DORIS_REQUEST_CONNECT_TIMEOUT_MS = "doris.request.connect.timeout.ms";
-    String DORIS_REQUEST_READ_TIMEOUT_MS = "doris.request.read.timeout.ms";
-    String DORIS_REQUEST_QUERY_TIMEOUT_S = "doris.request.query.timeout.s";
-    int DORIS_REQUEST_RETRIES_DEFAULT = 3;
-    int DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT = 30 * 1000;
-    int DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT = 30 * 1000;
-    int DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT = 3600;
+  String DORIS_REQUEST_RETRIES = "doris.request.retries";
+  String DORIS_REQUEST_CONNECT_TIMEOUT_MS = "doris.request.connect.timeout.ms";
+  String DORIS_REQUEST_READ_TIMEOUT_MS = "doris.request.read.timeout.ms";
+  String DORIS_REQUEST_QUERY_TIMEOUT_S = "doris.request.query.timeout.s";
+  int DORIS_REQUEST_RETRIES_DEFAULT = 3;
+  int DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT = 30 * 1000;
+  int DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT = 30 * 1000;
+  int DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT = 3600;
 
-    String DORIS_TABLET_SIZE = "doris.request.tablet.size";
-    int DORIS_TABLET_SIZE_DEFAULT = Integer.MAX_VALUE;
-    int DORIS_TABLET_SIZE_MIN = 1;
+  String DORIS_TABLET_SIZE = "doris.request.tablet.size";
+  int DORIS_TABLET_SIZE_DEFAULT = Integer.MAX_VALUE;
+  int DORIS_TABLET_SIZE_MIN = 1;
 
-    String DORIS_BATCH_SIZE = "doris.batch.size";
-    int DORIS_BATCH_SIZE_DEFAULT = 1024;
+  String DORIS_BATCH_SIZE = "doris.batch.size";
+  int DORIS_BATCH_SIZE_DEFAULT = 1024;
 
-    String DORIS_EXEC_MEM_LIMIT = "doris.exec.mem.limit";
-    long DORIS_EXEC_MEM_LIMIT_DEFAULT = 2147483648L;
+  String DORIS_EXEC_MEM_LIMIT = "doris.exec.mem.limit";
+  long DORIS_EXEC_MEM_LIMIT_DEFAULT = 2147483648L;
 
-    String DORIS_VALUE_READER_CLASS = "doris.value.reader.class";
+  String DORIS_VALUE_READER_CLASS = "doris.value.reader.class";
 
-    String DORIS_DESERIALIZE_ARROW_ASYNC = "doris.deserialize.arrow.async";
-    boolean DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT = false;
+  String DORIS_DESERIALIZE_ARROW_ASYNC = "doris.deserialize.arrow.async";
+  boolean DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT = false;
 
-    String DORIS_DESERIALIZE_QUEUE_SIZE = "doris.deserialize.queue.size";
-    int DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT = 64;
+  String DORIS_DESERIALIZE_QUEUE_SIZE = "doris.deserialize.queue.size";
+  int DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT = 64;
 
-    String DORIS_WRITE_FIELDS = "doris.write.fields";
+  String DORIS_WRITE_FIELDS = "doris.write.fields";
 
-    String DORIS_SINK_BATCH_SIZE = "doris.sink.batch.size";
-    int SINK_BATCH_SIZE_DEFAULT = 10000;
+  String DORIS_SINK_BATCH_SIZE = "doris.sink.batch.size";
+  int SINK_BATCH_SIZE_DEFAULT = 10000;
 
-    String DORIS_SINK_MAX_RETRIES = "doris.sink.max-retries";
-    int SINK_MAX_RETRIES_DEFAULT = 1;
+  String DORIS_SINK_MAX_RETRIES = "doris.sink.max-retries";
+  int SINK_MAX_RETRIES_DEFAULT = 1;
 
-    String DORIS_MAX_FILTER_RATIO = "doris.max.filter.ratio";
+  String DORIS_MAX_FILTER_RATIO = "doris.max.filter.ratio";
 
-    String STREAM_LOAD_PROP_PREFIX = "doris.sink.properties.";
+  String STREAM_LOAD_PROP_PREFIX = "doris.sink.properties.";
 
-    String DORIS_SINK_TASK_PARTITION_SIZE = "doris.sink.task.partition.size";
+  String DORIS_SINK_TASK_PARTITION_SIZE = "doris.sink.task.partition.size";
 
-    /**
-     * Set doris sink task partition size. If you set a small coalesce size and you don't have the action operations, this may result in the same parallelism in your computation.
-     * To avoid this, you can use repartition operations. This will add a shuffle step, but means the current upstream partitions will be executed in parallel.
-     */
-    String DORIS_SINK_TASK_USE_REPARTITION = "doris.sink.task.use.repartition";
+  /**
+   * Set doris sink task partition size. If you set a small coalesce size and you don't have the
+   * action operations, this may result in the same parallelism in your computation. To avoid this,
+   * you can use repartition operations. This will add a shuffle step, but means the current
+   * upstream partitions will be executed in parallel.
+   */
+  String DORIS_SINK_TASK_USE_REPARTITION = "doris.sink.task.use.repartition";
 
-    boolean DORIS_SINK_TASK_USE_REPARTITION_DEFAULT = false;
+  boolean DORIS_SINK_TASK_USE_REPARTITION_DEFAULT = false;
 
-    String DORIS_SINK_BATCH_INTERVAL_MS = "doris.sink.batch.interval.ms";
+  String DORIS_SINK_BATCH_INTERVAL_MS = "doris.sink.batch.interval.ms";
 
-    int DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT = 50;
-
+  int DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT = 50;
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/PropertiesSettings.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/PropertiesSettings.java
@@ -17,40 +17,39 @@
 
 package org.apache.doris.spark.cfg;
 
-import java.util.Properties;
-
 import com.google.common.base.Preconditions;
+import java.util.Properties;
 
 public class PropertiesSettings extends Settings {
 
-    protected final Properties props;
+  protected final Properties props;
 
-    public PropertiesSettings() {
-        this(new Properties());
-    }
+  public PropertiesSettings() {
+    this(new Properties());
+  }
 
-    public PropertiesSettings(Properties props) {
-        Preconditions.checkArgument(props != null, "non-null props configuration expected.");
-        this.props = props;
-    }
+  public PropertiesSettings(Properties props) {
+    Preconditions.checkArgument(props != null, "non-null props configuration expected.");
+    this.props = props;
+  }
 
-    @Override
-    public String getProperty(String name) {
-        return props.getProperty(name);
-    }
+  @Override
+  public String getProperty(String name) {
+    return props.getProperty(name);
+  }
 
-    @Override
-    public void setProperty(String name, String value) {
-        props.setProperty(name, value);
-    }
+  @Override
+  public void setProperty(String name, String value) {
+    props.setProperty(name, value);
+  }
 
-    @Override
-    public Settings copy() {
-        return new PropertiesSettings((Properties) props.clone());
-    }
+  @Override
+  public Settings copy() {
+    return new PropertiesSettings((Properties) props.clone());
+  }
 
-    @Override
-    public Properties asProperties() {
-        return props;
-    }
+  @Override
+  public Properties asProperties() {
+    return props;
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/ConnectedFailedException.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/ConnectedFailedException.java
@@ -18,11 +18,11 @@
 package org.apache.doris.spark.exception;
 
 public class ConnectedFailedException extends DorisException {
-    public ConnectedFailedException(String server, Throwable cause) {
-        super("Connect to " + server + "failed.", cause);
-    }
+  public ConnectedFailedException(String server, Throwable cause) {
+    super("Connect to " + server + "failed.", cause);
+  }
 
-    public ConnectedFailedException(String server, int statusCode, Throwable cause) {
-        super("Connect to " + server + "failed, status code is " + statusCode + ".", cause);
-    }
+  public ConnectedFailedException(String server, int statusCode, Throwable cause) {
+    super("Connect to " + server + "failed, status code is " + statusCode + ".", cause);
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/DorisException.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/DorisException.java
@@ -18,21 +18,24 @@
 package org.apache.doris.spark.exception;
 
 public class DorisException extends Exception {
-    public DorisException() {
-        super();
-    }
-    public DorisException(String message) {
-        super(message);
-    }
-    public DorisException(String message, Throwable cause) {
-        super(message, cause);
-    }
-    public DorisException(Throwable cause) {
-        super(cause);
-    }
-    protected DorisException(String message, Throwable cause,
-                        boolean enableSuppression,
-                        boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
+  public DorisException() {
+    super();
+  }
+
+  public DorisException(String message) {
+    super(message);
+  }
+
+  public DorisException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DorisException(Throwable cause) {
+    super(cause);
+  }
+
+  protected DorisException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/DorisInternalException.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/DorisInternalException.java
@@ -17,13 +17,17 @@
 
 package org.apache.doris.spark.exception;
 
+import java.util.List;
 import org.apache.doris.thrift.TStatusCode;
 
-import java.util.List;
-
 public class DorisInternalException extends DorisException {
-    public DorisInternalException(String server, TStatusCode statusCode, List<String> errorMsgs) {
-        super("Doris server " + server + " internal failed, status code [" + statusCode + "] error message is " + errorMsgs);
-    }
-
+  public DorisInternalException(String server, TStatusCode statusCode, List<String> errorMsgs) {
+    super(
+        "Doris server "
+            + server
+            + " internal failed, status code ["
+            + statusCode
+            + "] error message is "
+            + errorMsgs);
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/IllegalArgumentException.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/IllegalArgumentException.java
@@ -18,11 +18,11 @@
 package org.apache.doris.spark.exception;
 
 public class IllegalArgumentException extends DorisException {
-    public IllegalArgumentException(String msg, Throwable cause) {
-        super(msg, cause);
-    }
+  public IllegalArgumentException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
 
-    public IllegalArgumentException(String arg, String value) {
-        super("argument '" + arg + "' is illegal, value is '" + value + "'.");
-    }
+  public IllegalArgumentException(String arg, String value) {
+    super("argument '" + arg + "' is illegal, value is '" + value + "'.");
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/ShouldNeverHappenException.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/ShouldNeverHappenException.java
@@ -17,4 +17,4 @@
 
 package org.apache.doris.spark.exception;
 
-public class ShouldNeverHappenException extends DorisException { }
+public class ShouldNeverHappenException extends DorisException {}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/StreamLoadException.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/exception/StreamLoadException.java
@@ -18,21 +18,24 @@
 package org.apache.doris.spark.exception;
 
 public class StreamLoadException extends Exception {
-    public StreamLoadException() {
-        super();
-    }
-    public StreamLoadException(String message) {
-        super(message);
-    }
-    public StreamLoadException(String message, Throwable cause) {
-        super(message, cause);
-    }
-    public StreamLoadException(Throwable cause) {
-        super(cause);
-    }
-    protected StreamLoadException(String message, Throwable cause,
-                                  boolean enableSuppression,
-                                  boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
+  public StreamLoadException() {
+    super();
+  }
+
+  public StreamLoadException(String message) {
+    super(message);
+  }
+
+  public StreamLoadException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public StreamLoadException(Throwable cause) {
+    super(cause);
+  }
+
+  protected StreamLoadException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/PartitionDefinition.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/PartitionDefinition.java
@@ -22,134 +22,145 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
 import org.apache.doris.spark.cfg.PropertiesSettings;
 import org.apache.doris.spark.cfg.Settings;
 import org.apache.doris.spark.exception.IllegalArgumentException;
 
-/**
- * Doris RDD partition info.
- */
+/** Doris RDD partition info. */
 public class PartitionDefinition implements Serializable, Comparable<PartitionDefinition> {
-    private final String database;
-    private final String table;
+  private final String database;
+  private final String table;
 
-    private final String beAddress;
-    private final Set<Long> tabletIds;
-    private final String queryPlan;
-    private final String serializedSettings;
+  private final String beAddress;
+  private final Set<Long> tabletIds;
+  private final String queryPlan;
+  private final String serializedSettings;
 
-    public PartitionDefinition(String database, String table,
-            Settings settings, String beAddress, Set<Long> tabletIds, String queryPlan)
-            throws IllegalArgumentException {
-        if (settings != null) {
-            this.serializedSettings = settings.save();
-        } else {
-            this.serializedSettings = null;
-        }
-        this.database = database;
-        this.table = table;
-        this.beAddress = beAddress;
-        this.tabletIds = tabletIds;
-        this.queryPlan = queryPlan;
+  public PartitionDefinition(
+      String database,
+      String table,
+      Settings settings,
+      String beAddress,
+      Set<Long> tabletIds,
+      String queryPlan)
+      throws IllegalArgumentException {
+    if (settings != null) {
+      this.serializedSettings = settings.save();
+    } else {
+      this.serializedSettings = null;
+    }
+    this.database = database;
+    this.table = table;
+    this.beAddress = beAddress;
+    this.tabletIds = tabletIds;
+    this.queryPlan = queryPlan;
+  }
+
+  public String getBeAddress() {
+    return beAddress;
+  }
+
+  public Set<Long> getTabletIds() {
+    return tabletIds;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public String getQueryPlan() {
+    return queryPlan;
+  }
+
+  public Settings settings() throws IllegalArgumentException {
+    PropertiesSettings settings = new PropertiesSettings();
+    return serializedSettings != null ? settings.load(serializedSettings) : settings;
+  }
+
+  public int compareTo(PartitionDefinition o) {
+    int cmp = database.compareTo(o.database);
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp = table.compareTo(o.table);
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp = beAddress.compareTo(o.beAddress);
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp = queryPlan.compareTo(o.queryPlan);
+    if (cmp != 0) {
+      return cmp;
     }
 
-    public String getBeAddress() {
-        return beAddress;
+    cmp = tabletIds.size() - o.tabletIds.size();
+    if (cmp != 0) {
+      return cmp;
     }
 
-    public Set<Long> getTabletIds() {
-        return tabletIds;
+    Set<Long> similar = new HashSet<>(tabletIds);
+    Set<Long> diffSelf = new HashSet<>(tabletIds);
+    Set<Long> diffOther = new HashSet<>(o.tabletIds);
+    similar.retainAll(o.tabletIds);
+    diffSelf.removeAll(similar);
+    diffOther.removeAll(similar);
+    if (diffSelf.size() == 0) {
+      return 0;
     }
+    long diff = Collections.min(diffSelf) - Collections.min(diffOther);
+    return diff < 0 ? -1 : 1;
+  }
 
-    public String getDatabase() {
-        return database;
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
-
-    public String getTable() {
-        return table;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
+    PartitionDefinition that = (PartitionDefinition) o;
+    return Objects.equals(database, that.database)
+        && Objects.equals(table, that.table)
+        && Objects.equals(beAddress, that.beAddress)
+        && Objects.equals(tabletIds, that.tabletIds)
+        && Objects.equals(queryPlan, that.queryPlan)
+        && Objects.equals(serializedSettings, that.serializedSettings);
+  }
 
-    public String getQueryPlan() {
-        return queryPlan;
-    }
+  @Override
+  public int hashCode() {
+    int result = database.hashCode();
+    result = 31 * result + table.hashCode();
+    result = 31 * result + beAddress.hashCode();
+    result = 31 * result + queryPlan.hashCode();
+    result = 31 * result + tabletIds.hashCode();
+    return result;
+  }
 
-    public Settings settings() throws IllegalArgumentException {
-        PropertiesSettings settings = new PropertiesSettings();
-        return serializedSettings != null ? settings.load(serializedSettings) : settings;
-    }
-
-    public int compareTo(PartitionDefinition o) {
-        int cmp = database.compareTo(o.database);
-        if (cmp != 0) {
-            return cmp;
-        }
-        cmp = table.compareTo(o.table);
-        if (cmp != 0) {
-            return cmp;
-        }
-        cmp = beAddress.compareTo(o.beAddress);
-        if (cmp != 0) {
-            return cmp;
-        }
-        cmp = queryPlan.compareTo(o.queryPlan);
-        if (cmp != 0) {
-            return cmp;
-        }
-
-        cmp = tabletIds.size() - o.tabletIds.size();
-        if (cmp != 0) {
-            return cmp;
-        }
-
-        Set<Long> similar = new HashSet<>(tabletIds);
-        Set<Long> diffSelf = new HashSet<>(tabletIds);
-        Set<Long> diffOther = new HashSet<>(o.tabletIds);
-        similar.retainAll(o.tabletIds);
-        diffSelf.removeAll(similar);
-        diffOther.removeAll(similar);
-        if  (diffSelf.size() == 0) {
-            return 0;
-        }
-        long diff = Collections.min(diffSelf) - Collections.min(diffOther);
-        return diff < 0 ? -1 : 1;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        PartitionDefinition that = (PartitionDefinition) o;
-        return Objects.equals(database, that.database) &&
-                Objects.equals(table, that.table) &&
-                Objects.equals(beAddress, that.beAddress) &&
-                Objects.equals(tabletIds, that.tabletIds) &&
-                Objects.equals(queryPlan, that.queryPlan) &&
-                Objects.equals(serializedSettings, that.serializedSettings);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = database.hashCode();
-        result = 31 * result + table.hashCode();
-        result = 31 * result + beAddress.hashCode();
-        result = 31 * result + queryPlan.hashCode();
-        result = 31 * result + tabletIds.hashCode();
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return "PartitionDefinition{" +
-                ", database='" + database + '\'' +
-                ", table='" + table + '\'' +
-                ", beAddress='" + beAddress + '\'' +
-                ", tabletIds=" + tabletIds +
-                ", queryPlan='" + queryPlan + '\'' +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "PartitionDefinition{"
+        + ", database='"
+        + database
+        + '\''
+        + ", table='"
+        + table
+        + '\''
+        + ", beAddress='"
+        + beAddress
+        + '\''
+        + ", tabletIds="
+        + tabletIds
+        + ", queryPlan='"
+        + queryPlan
+        + '\''
+        + '}';
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/RestService.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/RestService.java
@@ -31,6 +31,10 @@ import static org.apache.doris.spark.util.ErrorMessages.ILLEGAL_ARGUMENT_MESSAGE
 import static org.apache.doris.spark.util.ErrorMessages.PARSE_NUMBER_FAILED_MESSAGE;
 import static org.apache.doris.spark.util.ErrorMessages.SHOULD_NOT_HAPPEN_MESSAGE;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,20 +44,16 @@ import java.io.Serializable;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Base64;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Set;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.doris.spark.cfg.ConfigurationOptions;
@@ -77,616 +77,686 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.slf4j.Logger;
 
-import com.google.common.annotations.VisibleForTesting;
-
-/**
- * Service for communicate with Doris FE.
- */
+/** Service for communicate with Doris FE. */
 public class RestService implements Serializable {
-    public final static int REST_RESPONSE_STATUS_OK = 200;
-    private static final String API_PREFIX = "/api";
-    private static final String SCHEMA = "_schema";
-    private static final String QUERY_PLAN = "_query_plan";
-    @Deprecated
-    private static final String BACKENDS = "/rest/v1/system?path=//backends";
-    private static final String BACKENDS_V2 = "/api/backends?is_alive=true";
+  public static final int REST_RESPONSE_STATUS_OK = 200;
+  private static final String API_PREFIX = "/api";
+  private static final String SCHEMA = "_schema";
+  private static final String QUERY_PLAN = "_query_plan";
+  @Deprecated private static final String BACKENDS = "/rest/v1/system?path=//backends";
+  private static final String BACKENDS_V2 = "/api/backends?is_alive=true";
 
-    /**
-     * send request to Doris FE and get response json string.
-     * @param cfg configuration of request
-     * @param request {@link HttpRequestBase} real request
-     * @param logger {@link Logger}
-     * @return Doris FE response in json string
-     * @throws ConnectedFailedException throw when cannot connect to Doris FE
-     */
-    private static String send(Settings cfg, HttpRequestBase request, Logger logger) throws
-            ConnectedFailedException {
-        int connectTimeout = cfg.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS,
-                ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT);
-        int socketTimeout = cfg.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS,
-                ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT);
-        int retries = cfg.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_RETRIES,
-                ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT);
-        logger.trace("connect timeout set to '{}'. socket timeout set to '{}'. retries set to '{}'.",
-                connectTimeout, socketTimeout, retries);
+  /**
+   * send request to Doris FE and get response json string.
+   *
+   * @param cfg configuration of request
+   * @param request {@link HttpRequestBase} real request
+   * @param logger {@link Logger}
+   * @return Doris FE response in json string
+   * @throws ConnectedFailedException throw when cannot connect to Doris FE
+   */
+  private static String send(Settings cfg, HttpRequestBase request, Logger logger)
+      throws ConnectedFailedException {
+    int connectTimeout =
+        cfg.getIntegerProperty(
+            ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS,
+            ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT);
+    int socketTimeout =
+        cfg.getIntegerProperty(
+            ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS,
+            ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT);
+    int retries =
+        cfg.getIntegerProperty(
+            ConfigurationOptions.DORIS_REQUEST_RETRIES,
+            ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT);
+    logger.trace(
+        "connect timeout set to '{}'. socket timeout set to '{}'. retries set to '{}'.",
+        connectTimeout,
+        socketTimeout,
+        retries);
 
-        RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(connectTimeout)
-                .setSocketTimeout(socketTimeout)
-                .build();
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setConnectTimeout(connectTimeout)
+            .setSocketTimeout(socketTimeout)
+            .build();
 
-        request.setConfig(requestConfig);
-        String user = cfg.getProperty(DORIS_REQUEST_AUTH_USER, "");
-        String password = cfg.getProperty(DORIS_REQUEST_AUTH_PASSWORD, "");
-        logger.info("Send request to Doris FE '{}' with user '{}'.", request.getURI(), user);
-        IOException ex = null;
-        int statusCode = -1;
+    request.setConfig(requestConfig);
+    String user = cfg.getProperty(DORIS_REQUEST_AUTH_USER, "");
+    String password = cfg.getProperty(DORIS_REQUEST_AUTH_PASSWORD, "");
+    logger.info("Send request to Doris FE '{}' with user '{}'.", request.getURI(), user);
+    IOException ex = null;
+    int statusCode = -1;
 
-        for (int attempt = 0; attempt < retries; attempt++) {
-            logger.debug("Attempt {} to request {}.", attempt, request.getURI());
-            try {
-                String response;
-                if (request instanceof HttpGet){
-                    response = getConnectionGet(request.getURI().toString(), user, password,logger);
-                } else {
-                    response = getConnectionPost(request,user, password,logger);
-                }
-                if (response == null) {
-                    logger.warn("Failed to get response from Doris FE {}, http code is {}",
-                            request.getURI(), statusCode);
-                    continue;
-                }
-                logger.trace("Success get response from Doris FE: {}, response is: {}.",
-                        request.getURI(), response);
-                ObjectMapper mapper = new ObjectMapper();
-                Map map = mapper.readValue(response, Map.class);
-                //Handle the problem of inconsistent data format returned by http v1 and v2
-                if (map.containsKey("code") && map.containsKey("msg")) {
-                    Object data = map.get("data");
-                    return mapper.writeValueAsString(data);
-                } else {
-                    return response;
-                }
-            } catch (IOException e) {
-                ex = e;
-                logger.warn(CONNECT_FAILED_MESSAGE, request.getURI(), e);
-            }
+    for (int attempt = 0; attempt < retries; attempt++) {
+      logger.debug("Attempt {} to request {}.", attempt, request.getURI());
+      try {
+        String response;
+        if (request instanceof HttpGet) {
+          response = getConnectionGet(request.getURI().toString(), user, password, logger);
+        } else {
+          response = getConnectionPost(request, user, password, logger);
         }
-
-        logger.error(CONNECT_FAILED_MESSAGE, request.getURI(), ex);
-        throw new ConnectedFailedException(request.getURI().toString(), statusCode, ex);
-    }
-
-    private static String getConnectionGet(String request,String user, String passwd,Logger logger) throws IOException {
-        URL realUrl = new URL(request);
-        // open connection
-        HttpURLConnection connection = (HttpURLConnection)realUrl.openConnection();
-        String authEncoding = Base64.getEncoder().encodeToString(String.format("%s:%s", user, passwd).getBytes(StandardCharsets.UTF_8));
-        connection.setRequestProperty("Authorization", "Basic " + authEncoding);
-
-        connection.connect();
-        return parseResponse(connection,logger);
-    }
-
-    private static String parseResponse(HttpURLConnection connection,Logger logger) throws IOException {
-        if (connection.getResponseCode() != HttpStatus.SC_OK) {
-            logger.warn("Failed to get response from Doris  {}, http code is {}",
-                    connection.getURL(), connection.getResponseCode());
-            throw new IOException("Failed to get response from Doris");
+        if (response == null) {
+          logger.warn(
+              "Failed to get response from Doris FE {}, http code is {}",
+              request.getURI(),
+              statusCode);
+          continue;
         }
-        StringBuilder result = new StringBuilder("");
-        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), "utf-8"));
-        String line;
-        while ((line = in.readLine()) != null) {
-            result.append(line);
-        }
-        if (in != null) {
-            in.close();
-        }
-        return result.toString();
-    }
-
-    private static String getConnectionPost(HttpRequestBase request,String user, String passwd,Logger logger) throws IOException {
-        URL url = new URL(request.getURI().toString());
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setInstanceFollowRedirects(false);
-        conn.setRequestMethod(request.getMethod());
-        String authEncoding = Base64.getEncoder().encodeToString(String.format("%s:%s", user, passwd).getBytes(StandardCharsets.UTF_8));
-        conn.setRequestProperty("Authorization", "Basic " + authEncoding);
-        InputStream content = ((HttpPost)request).getEntity().getContent();
-        String res = IOUtils.toString(content);
-        conn.setDoOutput(true);
-        conn.setDoInput(true);
-        PrintWriter out = new PrintWriter(conn.getOutputStream());
-        // send request params
-        out.print(res);
-        // flush
-        out.flush();
-        // read response
-        return parseResponse(conn,logger);
-    }
-    /**
-     * parse table identifier to array.
-     * @param tableIdentifier table identifier string
-     * @param logger {@link Logger}
-     * @return first element is db name, second element is table name
-     * @throws IllegalArgumentException table identifier is illegal
-     */
-    @VisibleForTesting
-    static String[] parseIdentifier(String tableIdentifier, Logger logger) throws IllegalArgumentException {
-        logger.trace("Parse identifier '{}'.", tableIdentifier);
-        if (StringUtils.isEmpty(tableIdentifier)) {
-            logger.error(ILLEGAL_ARGUMENT_MESSAGE, "table.identifier", tableIdentifier);
-            throw new IllegalArgumentException("table.identifier", tableIdentifier);
-        }
-        String[] identifier = tableIdentifier.split("\\.");
-        if (identifier.length != 2) {
-            logger.error(ILLEGAL_ARGUMENT_MESSAGE, "table.identifier", tableIdentifier);
-            throw new IllegalArgumentException("table.identifier", tableIdentifier);
-        }
-        return identifier;
-    }
-
-    /**
-     * choice a Doris FE node to request.
-     * @param feNodes Doris FE node list, separate be comma
-     * @param logger slf4j logger
-     * @return the chosen one Doris FE node
-     * @throws IllegalArgumentException fe nodes is illegal
-     */
-    @VisibleForTesting
-    static String randomEndpoint(String feNodes, Logger logger) throws IllegalArgumentException {
-        logger.trace("Parse fenodes '{}'.", feNodes);
-        if (StringUtils.isEmpty(feNodes)) {
-            logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
-            throw new IllegalArgumentException("fenodes", feNodes);
-        }
-        List<String> nodes = Arrays.asList(feNodes.split(","));
-        Collections.shuffle(nodes);
-        return nodes.get(0).trim();
-    }
-
-    /**
-     * get a valid URI to connect Doris FE.
-     * @param cfg configuration of request
-     * @param logger {@link Logger}
-     * @return uri string
-     * @throws IllegalArgumentException throw when configuration is illegal
-     */
-    @VisibleForTesting
-    static String getUriStr(Settings cfg, Logger logger) throws IllegalArgumentException {
-        String[] identifier = parseIdentifier(cfg.getProperty(DORIS_TABLE_IDENTIFIER), logger);
-        return "http://" +
-                randomEndpoint(cfg.getProperty(DORIS_FENODES), logger) + API_PREFIX +
-                "/" + identifier[0] +
-                "/" + identifier[1] +
-                "/";
-    }
-
-    @VisibleForTesting
-    static String getUriStr(String feNode,Settings cfg, Logger logger) throws IllegalArgumentException {
-        String[] identifier = parseIdentifier(cfg.getProperty(DORIS_TABLE_IDENTIFIER), logger);
-        return "http://" +
-                feNode + API_PREFIX +
-                "/" + identifier[0] +
-                "/" + identifier[1] +
-                "/";
-    }
-
-
-    /**
-     * discover Doris table schema from Doris FE.
-     * @param cfg configuration of request
-     * @param logger slf4j logger
-     * @return Doris table schema
-     * @throws DorisException throw when discover failed
-     */
-    public static Schema getSchema(Settings cfg, Logger logger)
-            throws DorisException {
-        logger.trace("Finding schema.");
-        List<String> feNodeList = allEndpoints(cfg.getProperty(DORIS_FENODES), logger);
-        for (String feNode: feNodeList) {
-            try {
-                HttpGet httpGet = new HttpGet(getUriStr(feNode,cfg, logger) + SCHEMA);
-                String response = send(cfg, httpGet, logger);
-                logger.debug("Find schema response is '{}'.", response);
-                return parseSchema(response, logger);
-            } catch (ConnectedFailedException e) {
-                logger.info("Doris FE node {} is unavailable: {}, Request the next Doris FE node", feNode, e.getMessage());
-            }
-        }
-        String errMsg = "No Doris FE is available, please check configuration";
-        logger.error(errMsg);
-        throw new DorisException(errMsg);
-    }
-
-    /**
-     * translate Doris FE response to inner {@link Schema} struct.
-     * @param response Doris FE response
-     * @param logger {@link Logger}
-     * @return inner {@link Schema} struct
-     * @throws DorisException throw when translate failed
-     */
-    @VisibleForTesting
-    public static Schema parseSchema(String response, Logger logger) throws DorisException {
-        logger.trace("Parse response '{}' to schema.", response);
+        logger.trace(
+            "Success get response from Doris FE: {}, response is: {}.", request.getURI(), response);
         ObjectMapper mapper = new ObjectMapper();
-        Schema schema;
-        try {
-            schema = mapper.readValue(response, Schema.class);
-        } catch (JsonParseException e) {
-            String errMsg = "Doris FE's response is not a json. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (JsonMappingException e) {
-            String errMsg = "Doris FE's response cannot map to schema. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (IOException e) {
-            String errMsg = "Parse Doris FE's response to json failed. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
+        Map map = mapper.readValue(response, Map.class);
+        // Handle the problem of inconsistent data format returned by http v1 and v2
+        if (map.containsKey("code") && map.containsKey("msg")) {
+          Object data = map.get("data");
+          return mapper.writeValueAsString(data);
+        } else {
+          return response;
         }
-
-        if (schema == null) {
-            logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
-            throw new ShouldNeverHappenException();
-        }
-
-        if (schema.getStatus() != REST_RESPONSE_STATUS_OK) {
-            String errMsg = "Doris FE's response is not OK, status is " + schema.getStatus();
-            logger.error(errMsg);
-            throw new DorisException(errMsg);
-        }
-        logger.debug("Parsing schema result is '{}'.", schema);
-        return schema;
+      } catch (IOException e) {
+        ex = e;
+        logger.warn(CONNECT_FAILED_MESSAGE, request.getURI(), e);
+      }
     }
 
-    /**
-     * find Doris RDD partitions from Doris FE.
-     * @param cfg configuration of request
-     * @param logger {@link Logger}
-     * @return an list of Doris RDD partitions
-     * @throws DorisException throw when find partition failed
-     */
-    public static List<PartitionDefinition> findPartitions(Settings cfg, Logger logger) throws DorisException {
-        String[] tableIdentifiers = parseIdentifier(cfg.getProperty(DORIS_TABLE_IDENTIFIER), logger);
-        String sql = "select " + cfg.getProperty(DORIS_READ_FIELD, "*") +
-                " from `" + tableIdentifiers[0] + "`.`" + tableIdentifiers[1] + "`";
-        if (!StringUtils.isEmpty(cfg.getProperty(DORIS_FILTER_QUERY))) {
-            sql += " where " + cfg.getProperty(DORIS_FILTER_QUERY);
-        }
-        logger.debug("Query SQL Sending to Doris FE is: '{}'.", sql);
+    logger.error(CONNECT_FAILED_MESSAGE, request.getURI(), ex);
+    throw new ConnectedFailedException(request.getURI().toString(), statusCode, ex);
+  }
 
-        List<String> feNodeList = allEndpoints(cfg.getProperty(DORIS_FENODES), logger);
-        for (String feNode: feNodeList) {
-            try {
-                HttpPost httpPost = new HttpPost(getUriStr(feNode,cfg, logger) + QUERY_PLAN);
-                String entity = "{\"sql\": \""+ sql +"\"}";
-                logger.debug("Post body Sending to Doris FE is: '{}'.", entity);
-                StringEntity stringEntity = new StringEntity(entity, StandardCharsets.UTF_8);
-                stringEntity.setContentEncoding("UTF-8");
-                stringEntity.setContentType("application/json");
-                httpPost.setEntity(stringEntity);
+  private static String getConnectionGet(String request, String user, String passwd, Logger logger)
+      throws IOException {
+    URL realUrl = new URL(request);
+    // open connection
+    HttpURLConnection connection = (HttpURLConnection) realUrl.openConnection();
+    String authEncoding =
+        Base64.getEncoder()
+            .encodeToString(String.format("%s:%s", user, passwd).getBytes(StandardCharsets.UTF_8));
+    connection.setRequestProperty("Authorization", "Basic " + authEncoding);
 
-                String resStr = send(cfg, httpPost, logger);
-                logger.debug("Find partition response is '{}'.", resStr);
-                QueryPlan queryPlan = getQueryPlan(resStr, logger);
-                Map<String, List<Long>> be2Tablets = selectBeForTablet(queryPlan, logger);
-                return tabletsMapToPartition(
-                        cfg,
-                        be2Tablets,
-                        queryPlan.getOpaqued_query_plan(),
-                        tableIdentifiers[0],
-                        tableIdentifiers[1],
-                        logger);
-            } catch (ConnectedFailedException e) {
-                logger.info("Doris FE node {} is unavailable: {}, Request the next Doris FE node", feNode, e.getMessage());
-            }
+    connection.connect();
+    return parseResponse(connection, logger);
+  }
+
+  private static String parseResponse(HttpURLConnection connection, Logger logger)
+      throws IOException {
+    if (connection.getResponseCode() != HttpStatus.SC_OK) {
+      logger.warn(
+          "Failed to get response from Doris  {}, http code is {}",
+          connection.getURL(),
+          connection.getResponseCode());
+      throw new IOException("Failed to get response from Doris");
+    }
+    StringBuilder result = new StringBuilder("");
+    BufferedReader in =
+        new BufferedReader(new InputStreamReader(connection.getInputStream(), "utf-8"));
+    String line;
+    while ((line = in.readLine()) != null) {
+      result.append(line);
+    }
+    if (in != null) {
+      in.close();
+    }
+    return result.toString();
+  }
+
+  private static String getConnectionPost(
+      HttpRequestBase request, String user, String passwd, Logger logger) throws IOException {
+    URL url = new URL(request.getURI().toString());
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setInstanceFollowRedirects(false);
+    conn.setRequestMethod(request.getMethod());
+    String authEncoding =
+        Base64.getEncoder()
+            .encodeToString(String.format("%s:%s", user, passwd).getBytes(StandardCharsets.UTF_8));
+    conn.setRequestProperty("Authorization", "Basic " + authEncoding);
+    InputStream content = ((HttpPost) request).getEntity().getContent();
+    String res = IOUtils.toString(content);
+    conn.setDoOutput(true);
+    conn.setDoInput(true);
+    PrintWriter out = new PrintWriter(conn.getOutputStream());
+    // send request params
+    out.print(res);
+    // flush
+    out.flush();
+    // read response
+    return parseResponse(conn, logger);
+  }
+  /**
+   * parse table identifier to array.
+   *
+   * @param tableIdentifier table identifier string
+   * @param logger {@link Logger}
+   * @return first element is db name, second element is table name
+   * @throws IllegalArgumentException table identifier is illegal
+   */
+  @VisibleForTesting
+  static String[] parseIdentifier(String tableIdentifier, Logger logger)
+      throws IllegalArgumentException {
+    logger.trace("Parse identifier '{}'.", tableIdentifier);
+    if (StringUtils.isEmpty(tableIdentifier)) {
+      logger.error(ILLEGAL_ARGUMENT_MESSAGE, "table.identifier", tableIdentifier);
+      throw new IllegalArgumentException("table.identifier", tableIdentifier);
+    }
+    String[] identifier = tableIdentifier.split("\\.");
+    if (identifier.length != 2) {
+      logger.error(ILLEGAL_ARGUMENT_MESSAGE, "table.identifier", tableIdentifier);
+      throw new IllegalArgumentException("table.identifier", tableIdentifier);
+    }
+    return identifier;
+  }
+
+  /**
+   * choice a Doris FE node to request.
+   *
+   * @param feNodes Doris FE node list, separate be comma
+   * @param logger slf4j logger
+   * @return the chosen one Doris FE node
+   * @throws IllegalArgumentException fe nodes is illegal
+   */
+  @VisibleForTesting
+  static String randomEndpoint(String feNodes, Logger logger) throws IllegalArgumentException {
+    logger.trace("Parse fenodes '{}'.", feNodes);
+    if (StringUtils.isEmpty(feNodes)) {
+      logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
+      throw new IllegalArgumentException("fenodes", feNodes);
+    }
+    List<String> nodes = Arrays.asList(feNodes.split(","));
+    Collections.shuffle(nodes);
+    return nodes.get(0).trim();
+  }
+
+  /**
+   * get a valid URI to connect Doris FE.
+   *
+   * @param cfg configuration of request
+   * @param logger {@link Logger}
+   * @return uri string
+   * @throws IllegalArgumentException throw when configuration is illegal
+   */
+  @VisibleForTesting
+  static String getUriStr(Settings cfg, Logger logger) throws IllegalArgumentException {
+    String[] identifier = parseIdentifier(cfg.getProperty(DORIS_TABLE_IDENTIFIER), logger);
+    return "http://"
+        + randomEndpoint(cfg.getProperty(DORIS_FENODES), logger)
+        + API_PREFIX
+        + "/"
+        + identifier[0]
+        + "/"
+        + identifier[1]
+        + "/";
+  }
+
+  @VisibleForTesting
+  static String getUriStr(String feNode, Settings cfg, Logger logger)
+      throws IllegalArgumentException {
+    String[] identifier = parseIdentifier(cfg.getProperty(DORIS_TABLE_IDENTIFIER), logger);
+    return "http://" + feNode + API_PREFIX + "/" + identifier[0] + "/" + identifier[1] + "/";
+  }
+
+  /**
+   * discover Doris table schema from Doris FE.
+   *
+   * @param cfg configuration of request
+   * @param logger slf4j logger
+   * @return Doris table schema
+   * @throws DorisException throw when discover failed
+   */
+  public static Schema getSchema(Settings cfg, Logger logger) throws DorisException {
+    logger.trace("Finding schema.");
+    List<String> feNodeList = allEndpoints(cfg.getProperty(DORIS_FENODES), logger);
+    for (String feNode : feNodeList) {
+      try {
+        HttpGet httpGet = new HttpGet(getUriStr(feNode, cfg, logger) + SCHEMA);
+        String response = send(cfg, httpGet, logger);
+        logger.debug("Find schema response is '{}'.", response);
+        return parseSchema(response, logger);
+      } catch (ConnectedFailedException e) {
+        logger.info(
+            "Doris FE node {} is unavailable: {}, Request the next Doris FE node",
+            feNode,
+            e.getMessage());
+      }
+    }
+    String errMsg = "No Doris FE is available, please check configuration";
+    logger.error(errMsg);
+    throw new DorisException(errMsg);
+  }
+
+  /**
+   * translate Doris FE response to inner {@link Schema} struct.
+   *
+   * @param response Doris FE response
+   * @param logger {@link Logger}
+   * @return inner {@link Schema} struct
+   * @throws DorisException throw when translate failed
+   */
+  @VisibleForTesting
+  public static Schema parseSchema(String response, Logger logger) throws DorisException {
+    logger.trace("Parse response '{}' to schema.", response);
+    ObjectMapper mapper = new ObjectMapper();
+    Schema schema;
+    try {
+      schema = mapper.readValue(response, Schema.class);
+    } catch (JsonParseException e) {
+      String errMsg = "Doris FE's response is not a json. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (JsonMappingException e) {
+      String errMsg = "Doris FE's response cannot map to schema. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (IOException e) {
+      String errMsg = "Parse Doris FE's response to json failed. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    }
+
+    if (schema == null) {
+      logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
+      throw new ShouldNeverHappenException();
+    }
+
+    if (schema.getStatus() != REST_RESPONSE_STATUS_OK) {
+      String errMsg = "Doris FE's response is not OK, status is " + schema.getStatus();
+      logger.error(errMsg);
+      throw new DorisException(errMsg);
+    }
+    logger.debug("Parsing schema result is '{}'.", schema);
+    return schema;
+  }
+
+  /**
+   * find Doris RDD partitions from Doris FE.
+   *
+   * @param cfg configuration of request
+   * @param logger {@link Logger}
+   * @return an list of Doris RDD partitions
+   * @throws DorisException throw when find partition failed
+   */
+  public static List<PartitionDefinition> findPartitions(Settings cfg, Logger logger)
+      throws DorisException {
+    String[] tableIdentifiers = parseIdentifier(cfg.getProperty(DORIS_TABLE_IDENTIFIER), logger);
+    String sql =
+        "select "
+            + cfg.getProperty(DORIS_READ_FIELD, "*")
+            + " from `"
+            + tableIdentifiers[0]
+            + "`.`"
+            + tableIdentifiers[1]
+            + "`";
+    if (!StringUtils.isEmpty(cfg.getProperty(DORIS_FILTER_QUERY))) {
+      sql += " where " + cfg.getProperty(DORIS_FILTER_QUERY);
+    }
+    logger.debug("Query SQL Sending to Doris FE is: '{}'.", sql);
+
+    List<String> feNodeList = allEndpoints(cfg.getProperty(DORIS_FENODES), logger);
+    for (String feNode : feNodeList) {
+      try {
+        HttpPost httpPost = new HttpPost(getUriStr(feNode, cfg, logger) + QUERY_PLAN);
+        String entity = "{\"sql\": \"" + sql + "\"}";
+        logger.debug("Post body Sending to Doris FE is: '{}'.", entity);
+        StringEntity stringEntity = new StringEntity(entity, StandardCharsets.UTF_8);
+        stringEntity.setContentEncoding("UTF-8");
+        stringEntity.setContentType("application/json");
+        httpPost.setEntity(stringEntity);
+
+        String resStr = send(cfg, httpPost, logger);
+        logger.debug("Find partition response is '{}'.", resStr);
+        QueryPlan queryPlan = getQueryPlan(resStr, logger);
+        Map<String, List<Long>> be2Tablets = selectBeForTablet(queryPlan, logger);
+        return tabletsMapToPartition(
+            cfg,
+            be2Tablets,
+            queryPlan.getOpaqued_query_plan(),
+            tableIdentifiers[0],
+            tableIdentifiers[1],
+            logger);
+      } catch (ConnectedFailedException e) {
+        logger.info(
+            "Doris FE node {} is unavailable: {}, Request the next Doris FE node",
+            feNode,
+            e.getMessage());
+      }
+    }
+    String errMsg = "No Doris FE is available, please check configuration";
+    logger.error(errMsg);
+    throw new DorisException(errMsg);
+  }
+
+  /**
+   * translate Doris FE response string to inner {@link QueryPlan} struct.
+   *
+   * @param response Doris FE response string
+   * @param logger {@link Logger}
+   * @return inner {@link QueryPlan} struct
+   * @throws DorisException throw when translate failed.
+   */
+  @VisibleForTesting
+  static QueryPlan getQueryPlan(String response, Logger logger) throws DorisException {
+    ObjectMapper mapper = new ObjectMapper();
+    QueryPlan queryPlan;
+    try {
+      queryPlan = mapper.readValue(response, QueryPlan.class);
+    } catch (JsonParseException e) {
+      String errMsg = "Doris FE's response is not a json. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (JsonMappingException e) {
+      String errMsg = "Doris FE's response cannot map to schema. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (IOException e) {
+      String errMsg = "Parse Doris FE's response to json failed. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    }
+
+    if (queryPlan == null) {
+      logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
+      throw new ShouldNeverHappenException();
+    }
+
+    if (queryPlan.getStatus() != REST_RESPONSE_STATUS_OK) {
+      String errMsg = "Doris FE's response is not OK, status is " + queryPlan.getStatus();
+      logger.error(errMsg);
+      throw new DorisException(errMsg);
+    }
+    logger.debug("Parsing partition result is '{}'.", queryPlan);
+    return queryPlan;
+  }
+
+  /**
+   * select which Doris BE to get tablet data.
+   *
+   * @param queryPlan {@link QueryPlan} translated from Doris FE response
+   * @param logger {@link Logger}
+   * @return BE to tablets {@link Map}
+   * @throws DorisException throw when select failed.
+   */
+  @VisibleForTesting
+  static Map<String, List<Long>> selectBeForTablet(QueryPlan queryPlan, Logger logger)
+      throws DorisException {
+    Map<String, List<Long>> be2Tablets = new HashMap<>();
+    for (Map.Entry<String, Tablet> part : queryPlan.getPartitions().entrySet()) {
+      logger.debug("Parse tablet info: '{}'.", part);
+      long tabletId;
+      try {
+        tabletId = Long.parseLong(part.getKey());
+      } catch (NumberFormatException e) {
+        String errMsg = "Parse tablet id '" + part.getKey() + "' to long failed.";
+        logger.error(errMsg, e);
+        throw new DorisException(errMsg, e);
+      }
+      String target = null;
+      int tabletCount = Integer.MAX_VALUE;
+      for (String candidate : part.getValue().getRoutings()) {
+        logger.trace("Evaluate Doris BE '{}' to tablet '{}'.", candidate, tabletId);
+        if (!be2Tablets.containsKey(candidate)) {
+          logger.debug("Choice a new Doris BE '{}' for tablet '{}'.", candidate, tabletId);
+          List<Long> tablets = new ArrayList<>();
+          be2Tablets.put(candidate, tablets);
+          target = candidate;
+          break;
+        } else {
+          if (be2Tablets.get(candidate).size() < tabletCount) {
+            target = candidate;
+            tabletCount = be2Tablets.get(candidate).size();
+            logger.debug(
+                "Current candidate Doris BE to tablet '{}' is '{}' with tablet count {}.",
+                tabletId,
+                target,
+                tabletCount);
+          }
         }
-        String errMsg = "No Doris FE is available, please check configuration";
+      }
+      if (target == null) {
+        String errMsg = "Cannot choice Doris BE for tablet " + tabletId;
         logger.error(errMsg);
         throw new DorisException(errMsg);
+      }
 
+      logger.debug("Choice Doris BE '{}' for tablet '{}'.", target, tabletId);
+      be2Tablets.get(target).add(tabletId);
+    }
+    return be2Tablets;
+  }
+
+  /**
+   * tablet count limit for one Doris RDD partition
+   *
+   * @param cfg configuration of request
+   * @param logger {@link Logger}
+   * @return tablet count limit
+   */
+  @VisibleForTesting
+  static int tabletCountLimitForOnePartition(Settings cfg, Logger logger) {
+    int tabletsSize = DORIS_TABLET_SIZE_DEFAULT;
+    if (cfg.getProperty(DORIS_TABLET_SIZE) != null) {
+      try {
+        tabletsSize = Integer.parseInt(cfg.getProperty(DORIS_TABLET_SIZE));
+      } catch (NumberFormatException e) {
+        logger.warn(
+            PARSE_NUMBER_FAILED_MESSAGE, DORIS_TABLET_SIZE, cfg.getProperty(DORIS_TABLET_SIZE));
+      }
+    }
+    if (tabletsSize < DORIS_TABLET_SIZE_MIN) {
+      logger.warn(
+          "{} is less than {}, set to default value {}.",
+          DORIS_TABLET_SIZE,
+          DORIS_TABLET_SIZE_MIN,
+          DORIS_TABLET_SIZE_MIN);
+      tabletsSize = DORIS_TABLET_SIZE_MIN;
+    }
+    logger.debug("Tablet size is set to {}.", tabletsSize);
+    return tabletsSize;
+  }
+
+  /**
+   * choice a Doris BE node to request.
+   *
+   * @param logger slf4j logger
+   * @return the chosen one Doris BE node
+   * @throws IllegalArgumentException BE nodes is illegal Deprecated, use randomBackendV2 instead
+   */
+  @Deprecated
+  @VisibleForTesting
+  public static String randomBackend(SparkSettings sparkSettings, Logger logger)
+      throws DorisException {
+    List<BackendV2.BackendRowV2> backends = getBackendRows(sparkSettings, logger);
+    Collections.shuffle(backends);
+    BackendV2.BackendRowV2 backend = backends.get(0);
+    return backend.getIp() + ":" + backend.getHttpPort();
+  }
+
+  /**
+   * translate Doris FE response to inner {@link BackendRow} struct.
+   *
+   * @param response Doris FE response
+   * @param logger {@link Logger}
+   * @return inner {@link List<BackendRow>} struct
+   * @throws DorisException,IOException throw when translate failed
+   */
+  @Deprecated
+  @VisibleForTesting
+  static List<BackendRow> parseBackend(String response, Logger logger)
+      throws DorisException, IOException {
+    com.fasterxml.jackson.databind.ObjectMapper mapper =
+        new com.fasterxml.jackson.databind.ObjectMapper();
+    Backend backend;
+    try {
+      backend = mapper.readValue(response, Backend.class);
+    } catch (com.fasterxml.jackson.core.JsonParseException e) {
+      String errMsg = "Doris BE's response is not a json. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (com.fasterxml.jackson.databind.JsonMappingException e) {
+      String errMsg = "Doris BE's response cannot map to schema. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (IOException e) {
+      String errMsg = "Parse Doris BE's response to json failed. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
     }
 
-    /**
-     * translate Doris FE response string to inner {@link QueryPlan} struct.
-     * @param response Doris FE response string
-     * @param logger {@link Logger}
-     * @return inner {@link QueryPlan} struct
-     * @throws DorisException throw when translate failed.
-     */
-    @VisibleForTesting
-    static QueryPlan getQueryPlan(String response, Logger logger) throws DorisException {
-        ObjectMapper mapper = new ObjectMapper();
-        QueryPlan queryPlan;
-        try {
-            queryPlan = mapper.readValue(response, QueryPlan.class);
-        } catch (JsonParseException e) {
-            String errMsg = "Doris FE's response is not a json. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (JsonMappingException e) {
-            String errMsg = "Doris FE's response cannot map to schema. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (IOException e) {
-            String errMsg = "Parse Doris FE's response to json failed. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        }
+    if (backend == null) {
+      logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
+      throw new ShouldNeverHappenException();
+    }
+    List<BackendRow> backendRows =
+        backend.getRows().stream().filter(v -> v.getAlive()).collect(Collectors.toList());
+    logger.debug("Parsing schema result is '{}'.", backendRows);
+    return backendRows;
+  }
 
-        if (queryPlan == null) {
-            logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
-            throw new ShouldNeverHappenException();
+  /**
+   * get Doris BE node list.
+   *
+   * @param logger slf4j logger
+   * @return the Doris BE node list
+   * @throws IllegalArgumentException BE nodes is illegal
+   */
+  @VisibleForTesting
+  public static List<BackendV2.BackendRowV2> getBackendRows(
+      SparkSettings sparkSettings, Logger logger) throws DorisException {
+    List<String> feNodeList = allEndpoints(sparkSettings.getProperty(DORIS_FENODES), logger);
+    for (String feNode : feNodeList) {
+      try {
+        String beUrl = String.format("http://%s" + BACKENDS_V2, feNode);
+        HttpGet httpGet = new HttpGet(beUrl);
+        String response = send(sparkSettings, httpGet, logger);
+        logger.info("Backend Info:{}", response);
+        List<BackendV2.BackendRowV2> backends = parseBackendV2(response, logger);
+        logger.trace("Parse beNodes '{}'.", backends);
+        if (backends == null || backends.isEmpty()) {
+          logger.error(ILLEGAL_ARGUMENT_MESSAGE, "beNodes", backends);
+          throw new IllegalArgumentException("beNodes", String.valueOf(backends));
         }
+        return backends;
+      } catch (ConnectedFailedException e) {
+        logger.info(
+            "Doris FE node {} is unavailable: {}, Request the next Doris FE node",
+            feNode,
+            e.getMessage());
+      }
+    }
+    String errMsg = "No Doris FE is available, please check configuration";
+    logger.error(errMsg);
+    throw new DorisException(errMsg);
+  }
 
-        if (queryPlan.getStatus() != REST_RESPONSE_STATUS_OK) {
-            String errMsg = "Doris FE's response is not OK, status is " + queryPlan.getStatus();
-            logger.error(errMsg);
-            throw new DorisException(errMsg);
-        }
-        logger.debug("Parsing partition result is '{}'.", queryPlan);
-        return queryPlan;
+  /**
+   * choice a Doris BE node to request.
+   *
+   * @param logger slf4j logger
+   * @return the chosen one Doris BE node
+   * @throws IllegalArgumentException BE nodes is illegal
+   */
+  @VisibleForTesting
+  public static String randomBackendV2(SparkSettings sparkSettings, Logger logger)
+      throws DorisException {
+    List<BackendV2.BackendRowV2> backends = getBackendRows(sparkSettings, logger);
+    Collections.shuffle(backends);
+    BackendV2.BackendRowV2 backend = backends.get(0);
+    return backend.getIp() + ":" + backend.getHttpPort();
+  }
+
+  static List<BackendV2.BackendRowV2> parseBackendV2(String response, Logger logger)
+      throws DorisException {
+    com.fasterxml.jackson.databind.ObjectMapper mapper =
+        new com.fasterxml.jackson.databind.ObjectMapper();
+    BackendV2 backend;
+    try {
+      backend = mapper.readValue(response, BackendV2.class);
+    } catch (com.fasterxml.jackson.core.JsonParseException e) {
+      String errMsg = "Doris BE's response is not a json. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (com.fasterxml.jackson.databind.JsonMappingException e) {
+      String errMsg = "Doris BE's response cannot map to schema. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
+    } catch (IOException e) {
+      String errMsg = "Parse Doris BE's response to json failed. res: " + response;
+      logger.error(errMsg, e);
+      throw new DorisException(errMsg, e);
     }
 
-    /**
-     * select which Doris BE to get tablet data.
-     * @param queryPlan {@link QueryPlan} translated from Doris FE response
-     * @param logger {@link Logger}
-     * @return BE to tablets {@link Map}
-     * @throws DorisException throw when select failed.
-     */
-    @VisibleForTesting
-    static  Map<String, List<Long>> selectBeForTablet(QueryPlan queryPlan, Logger logger) throws DorisException {
-        Map<String, List<Long>> be2Tablets = new HashMap<>();
-        for (Map.Entry<String, Tablet> part : queryPlan.getPartitions().entrySet()) {
-            logger.debug("Parse tablet info: '{}'.", part);
-            long tabletId;
-            try {
-                tabletId = Long.parseLong(part.getKey());
-            } catch (NumberFormatException e) {
-                String errMsg = "Parse tablet id '" + part.getKey() + "' to long failed.";
-                logger.error(errMsg, e);
-                throw new DorisException(errMsg, e);
-            }
-            String target = null;
-            int tabletCount = Integer.MAX_VALUE;
-            for (String candidate : part.getValue().getRoutings()) {
-                logger.trace("Evaluate Doris BE '{}' to tablet '{}'.", candidate, tabletId);
-                if (!be2Tablets.containsKey(candidate)) {
-                    logger.debug("Choice a new Doris BE '{}' for tablet '{}'.", candidate, tabletId);
-                    List<Long> tablets = new ArrayList<>();
-                    be2Tablets.put(candidate, tablets);
-                    target = candidate;
-                    break;
-                } else {
-                    if (be2Tablets.get(candidate).size() < tabletCount) {
-                        target = candidate;
-                        tabletCount = be2Tablets.get(candidate).size();
-                        logger.debug("Current candidate Doris BE to tablet '{}' is '{}' with tablet count {}.",
-                                tabletId, target, tabletCount);
-                    }
-                }
-            }
-            if (target == null) {
-                String errMsg = "Cannot choice Doris BE for tablet " + tabletId;
-                logger.error(errMsg);
-                throw new DorisException(errMsg);
-            }
-
-            logger.debug("Choice Doris BE '{}' for tablet '{}'.", target, tabletId);
-            be2Tablets.get(target).add(tabletId);
-        }
-        return be2Tablets;
+    if (backend == null) {
+      logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
+      throw new ShouldNeverHappenException();
     }
+    List<BackendV2.BackendRowV2> backendRows = backend.getBackends();
+    logger.debug("Parsing schema result is '{}'.", backendRows);
+    return backendRows;
+  }
 
-    /**
-     * tablet count limit for one Doris RDD partition
-     * @param cfg configuration of request
-     * @param logger {@link Logger}
-     * @return tablet count limit
-     */
-    @VisibleForTesting
-    static int tabletCountLimitForOnePartition(Settings cfg, Logger logger) {
-        int tabletsSize = DORIS_TABLET_SIZE_DEFAULT;
-        if (cfg.getProperty(DORIS_TABLET_SIZE) != null) {
-            try {
-                tabletsSize = Integer.parseInt(cfg.getProperty(DORIS_TABLET_SIZE));
-            } catch (NumberFormatException e) {
-                logger.warn(PARSE_NUMBER_FAILED_MESSAGE, DORIS_TABLET_SIZE, cfg.getProperty(DORIS_TABLET_SIZE));
-            }
-        }
-        if (tabletsSize < DORIS_TABLET_SIZE_MIN) {
-            logger.warn("{} is less than {}, set to default value {}.",
-                    DORIS_TABLET_SIZE, DORIS_TABLET_SIZE_MIN, DORIS_TABLET_SIZE_MIN);
-            tabletsSize = DORIS_TABLET_SIZE_MIN;
-        }
-        logger.debug("Tablet size is set to {}.", tabletsSize);
-        return tabletsSize;
+  /**
+   * translate BE tablets map to Doris RDD partition.
+   *
+   * @param cfg configuration of request
+   * @param be2Tablets BE to tablets {@link Map}
+   * @param opaquedQueryPlan Doris BE execute plan getting from Doris FE
+   * @param database database name of Doris table
+   * @param table table name of Doris table
+   * @param logger {@link Logger}
+   * @return Doris RDD partition {@link List}
+   * @throws IllegalArgumentException throw when translate failed
+   */
+  @VisibleForTesting
+  static List<PartitionDefinition> tabletsMapToPartition(
+      Settings cfg,
+      Map<String, List<Long>> be2Tablets,
+      String opaquedQueryPlan,
+      String database,
+      String table,
+      Logger logger)
+      throws IllegalArgumentException {
+    int tabletsSize = tabletCountLimitForOnePartition(cfg, logger);
+    List<PartitionDefinition> partitions = new ArrayList<>();
+    for (Map.Entry<String, List<Long>> beInfo : be2Tablets.entrySet()) {
+      logger.debug("Generate partition with beInfo: '{}'.", beInfo);
+      HashSet<Long> tabletSet = new HashSet<>(beInfo.getValue());
+      beInfo.getValue().clear();
+      beInfo.getValue().addAll(tabletSet);
+      int first = 0;
+      while (first < beInfo.getValue().size()) {
+        Set<Long> partitionTablets =
+            new HashSet<>(
+                beInfo
+                    .getValue()
+                    .subList(first, Math.min(beInfo.getValue().size(), first + tabletsSize)));
+        first = first + tabletsSize;
+        PartitionDefinition partitionDefinition =
+            new PartitionDefinition(
+                database, table, cfg, beInfo.getKey(), partitionTablets, opaquedQueryPlan);
+        logger.debug("Generate one PartitionDefinition '{}'.", partitionDefinition);
+        partitions.add(partitionDefinition);
+      }
     }
+    return partitions;
+  }
 
-    /**
-     * choice a Doris BE node to request.
-     * @param logger slf4j logger
-     * @return the chosen one Doris BE node
-     * @throws IllegalArgumentException BE nodes is illegal
-     * Deprecated, use randomBackendV2 instead
-     */
-    @Deprecated
-    @VisibleForTesting
-    public static String randomBackend(SparkSettings sparkSettings , Logger logger) throws DorisException {
-        List<BackendV2.BackendRowV2> backends = getBackendRows(sparkSettings, logger);
-        Collections.shuffle(backends);
-        BackendV2.BackendRowV2 backend = backends.get(0);
-        return backend.getIp()+ ":" + backend.getHttpPort();
+  /**
+   * choice a Doris FE node to request.
+   *
+   * @param feNodes Doris FE node list, separate be comma
+   * @param logger slf4j logger
+   * @return the array of Doris FE nodes
+   * @throws IllegalArgumentException fe nodes is illegal
+   */
+  @VisibleForTesting
+  static List<String> allEndpoints(String feNodes, Logger logger) throws IllegalArgumentException {
+    logger.trace("Parse fenodes '{}'.", feNodes);
+    if (StringUtils.isEmpty(feNodes)) {
+      logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
+      throw new IllegalArgumentException("fenodes", feNodes);
     }
-
-    /**
-     * translate Doris FE response to inner {@link BackendRow} struct.
-     * @param response Doris FE response
-     * @param logger {@link Logger}
-     * @return inner {@link List<BackendRow>} struct
-     * @throws DorisException,IOException throw when translate failed
-     * */
-    @Deprecated
-    @VisibleForTesting
-    static List<BackendRow> parseBackend(String response, Logger logger) throws DorisException, IOException {
-        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-        Backend backend;
-        try {
-            backend = mapper.readValue(response, Backend.class);
-        } catch (com.fasterxml.jackson.core.JsonParseException e) {
-            String errMsg = "Doris BE's response is not a json. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (com.fasterxml.jackson.databind.JsonMappingException e) {
-            String errMsg = "Doris BE's response cannot map to schema. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (IOException e) {
-            String errMsg = "Parse Doris BE's response to json failed. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        }
-
-        if (backend == null) {
-            logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
-            throw new ShouldNeverHappenException();
-        }
-        List<BackendRow> backendRows = backend.getRows().stream().filter(v -> v.getAlive()).collect(Collectors.toList());
-        logger.debug("Parsing schema result is '{}'.", backendRows);
-        return backendRows;
-    }
-
-    /**
-     * get Doris BE node list.
-     * @param logger slf4j logger
-     * @return the Doris BE node list
-     * @throws IllegalArgumentException BE nodes is illegal
-     */
-    @VisibleForTesting
-    public static List<BackendV2.BackendRowV2> getBackendRows(SparkSettings sparkSettings,  Logger logger) throws DorisException {
-        List<String> feNodeList = allEndpoints(sparkSettings.getProperty(DORIS_FENODES), logger);
-        for (String feNode : feNodeList){
-            try {
-                String beUrl =   String.format("http://%s" + BACKENDS_V2, feNode);
-                HttpGet httpGet = new HttpGet(beUrl);
-                String response = send(sparkSettings, httpGet, logger);
-                logger.info("Backend Info:{}", response);
-                List<BackendV2.BackendRowV2> backends = parseBackendV2(response, logger);
-                logger.trace("Parse beNodes '{}'.", backends);
-                if (backends == null || backends.isEmpty()) {
-                    logger.error(ILLEGAL_ARGUMENT_MESSAGE, "beNodes", backends);
-                    throw new IllegalArgumentException("beNodes", String.valueOf(backends));
-                }
-                return backends;
-            } catch (ConnectedFailedException e) {
-                logger.info("Doris FE node {} is unavailable: {}, Request the next Doris FE node", feNode, e.getMessage());
-            }
-        }
-        String errMsg = "No Doris FE is available, please check configuration";
-        logger.error(errMsg);
-        throw new DorisException(errMsg);
-    }
-
-    /**
-     * choice a Doris BE node to request.
-     * @param logger slf4j logger
-     * @return the chosen one Doris BE node
-     * @throws IllegalArgumentException BE nodes is illegal
-     */
-    @VisibleForTesting
-    public static String randomBackendV2(SparkSettings sparkSettings, Logger logger) throws DorisException {
-        List<BackendV2.BackendRowV2> backends = getBackendRows(sparkSettings, logger);
-        Collections.shuffle(backends);
-        BackendV2.BackendRowV2 backend = backends.get(0);
-        return backend.getIp() + ":" + backend.getHttpPort();
-    }
-
-    static List<BackendV2.BackendRowV2> parseBackendV2(String response, Logger logger) throws DorisException {
-        com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-        BackendV2 backend;
-        try {
-            backend = mapper.readValue(response, BackendV2.class);
-        } catch (com.fasterxml.jackson.core.JsonParseException e) {
-            String errMsg = "Doris BE's response is not a json. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (com.fasterxml.jackson.databind.JsonMappingException e) {
-            String errMsg = "Doris BE's response cannot map to schema. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        } catch (IOException e) {
-            String errMsg = "Parse Doris BE's response to json failed. res: " + response;
-            logger.error(errMsg, e);
-            throw new DorisException(errMsg, e);
-        }
-
-        if (backend == null) {
-            logger.error(SHOULD_NOT_HAPPEN_MESSAGE);
-            throw new ShouldNeverHappenException();
-        }
-        List<BackendV2.BackendRowV2> backendRows = backend.getBackends();
-        logger.debug("Parsing schema result is '{}'.", backendRows);
-        return backendRows;
-    }
-
-    /**
-     * translate BE tablets map to Doris RDD partition.
-     * @param cfg configuration of request
-     * @param be2Tablets BE to tablets {@link Map}
-     * @param opaquedQueryPlan Doris BE execute plan getting from Doris FE
-     * @param database database name of Doris table
-     * @param table table name of Doris table
-     * @param logger {@link Logger}
-     * @return Doris RDD partition {@link List}
-     * @throws IllegalArgumentException throw when translate failed
-     */
-    @VisibleForTesting
-    static List<PartitionDefinition> tabletsMapToPartition(Settings cfg, Map<String, List<Long>> be2Tablets,
-            String opaquedQueryPlan, String database, String table, Logger logger)
-            throws IllegalArgumentException {
-        int tabletsSize = tabletCountLimitForOnePartition(cfg, logger);
-        List<PartitionDefinition> partitions = new ArrayList<>();
-        for (Map.Entry<String, List<Long>> beInfo : be2Tablets.entrySet()) {
-            logger.debug("Generate partition with beInfo: '{}'.", beInfo);
-            HashSet<Long> tabletSet = new HashSet<>(beInfo.getValue());
-            beInfo.getValue().clear();
-            beInfo.getValue().addAll(tabletSet);
-            int first = 0;
-            while (first < beInfo.getValue().size()) {
-                Set<Long> partitionTablets = new HashSet<>(beInfo.getValue().subList(
-                        first, Math.min(beInfo.getValue().size(), first + tabletsSize)));
-                first = first + tabletsSize;
-                PartitionDefinition partitionDefinition =
-                        new PartitionDefinition(database, table, cfg,
-                                beInfo.getKey(), partitionTablets, opaquedQueryPlan);
-                logger.debug("Generate one PartitionDefinition '{}'.", partitionDefinition);
-                partitions.add(partitionDefinition);
-            }
-        }
-        return partitions;
-    }
-
-    /**
-     * choice a Doris FE node to request.
-     *
-     * @param feNodes Doris FE node list, separate be comma
-     * @param logger  slf4j logger
-     * @return the array of Doris FE nodes
-     * @throws IllegalArgumentException fe nodes is illegal
-     */
-    @VisibleForTesting
-    static List<String> allEndpoints(String feNodes, Logger logger) throws IllegalArgumentException {
-        logger.trace("Parse fenodes '{}'.", feNodes);
-        if (StringUtils.isEmpty(feNodes)) {
-            logger.error(ILLEGAL_ARGUMENT_MESSAGE, "fenodes", feNodes);
-            throw new IllegalArgumentException("fenodes", feNodes);
-        }
-        List<String> nodes = Arrays.stream(feNodes.split(",")).map(String::trim).collect(Collectors.toList());
-        Collections.shuffle(nodes);
-        return nodes;
-    }
+    List<String> nodes =
+        Arrays.stream(feNodes.split(",")).map(String::trim).collect(Collectors.toList());
+    Collections.shuffle(nodes);
+    return nodes;
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Backend.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Backend.java
@@ -15,26 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 package org.apache.doris.spark.rest.models;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
-/**
- * Be response model
- **/
+/** Be response model */
 @Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Backend {
 
-    @JsonProperty(value = "rows")
-    private List<BackendRow> rows;
+  @JsonProperty(value = "rows")
+  private List<BackendRow> rows;
 
-    public List<BackendRow> getRows() {
-        return rows;
-    }
+  public List<BackendRow> getRows() {
+    return rows;
+  }
 
-    public void setRows(List<BackendRow> rows) {
-        this.rows = rows;
-    }
+  public void setRows(List<BackendRow> rows) {
+    this.rows = rows;
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/BackendRow.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/BackendRow.java
@@ -23,45 +23,50 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BackendRow {
 
-    @JsonProperty(value = "HttpPort")
-    private String HttpPort;
+  @JsonProperty(value = "HttpPort")
+  private String HttpPort;
 
-    @JsonProperty(value = "IP")
-    private String IP;
+  @JsonProperty(value = "IP")
+  private String IP;
 
-    @JsonProperty(value = "Alive")
-    private Boolean Alive;
+  @JsonProperty(value = "Alive")
+  private Boolean Alive;
 
-    public String getHttpPort() {
-        return HttpPort;
-    }
+  public String getHttpPort() {
+    return HttpPort;
+  }
 
-    public void setHttpPort(String httpPort) {
-        HttpPort = httpPort;
-    }
+  public void setHttpPort(String httpPort) {
+    HttpPort = httpPort;
+  }
 
-    public String getIP() {
-        return IP;
-    }
+  public String getIP() {
+    return IP;
+  }
 
-    public void setIP(String IP) {
-        this.IP = IP;
-    }
+  public void setIP(String IP) {
+    this.IP = IP;
+  }
 
-    public Boolean getAlive() {
-        return Alive;
-    }
+  public Boolean getAlive() {
+    return Alive;
+  }
 
-    public void setAlive(Boolean alive) {
-        Alive = alive;
-    }
+  public void setAlive(Boolean alive) {
+    Alive = alive;
+  }
 
-    @Override
-    public String toString() {
-        return "BackendRow{" +
-                "HttpPort='" + HttpPort + '\'' +
-                ", IP='" + IP + '\'' +
-                ", Alive=" + Alive +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "BackendRow{"
+        + "HttpPort='"
+        + HttpPort
+        + '\''
+        + ", IP='"
+        + IP
+        + '\''
+        + ", Alive="
+        + Alive
+        + '}';
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/BackendV2.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/BackendV2.java
@@ -15,58 +15,58 @@
 // specific language governing permissions and limitations
 // under the License.
 package org.apache.doris.spark.rest.models;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
-/**
- * Be response model
- **/
+/** Be response model */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BackendV2 {
 
-    @JsonProperty(value = "backends")
-    private List<BackendRowV2> backends;
+  @JsonProperty(value = "backends")
+  private List<BackendRowV2> backends;
 
-    public List<BackendRowV2> getBackends() {
-        return backends;
+  public List<BackendRowV2> getBackends() {
+    return backends;
+  }
+
+  public void setRows(List<BackendRowV2> rows) {
+    this.backends = rows;
+  }
+
+  public static class BackendRowV2 {
+    @JsonProperty("ip")
+    public String ip;
+
+    @JsonProperty("http_port")
+    public int httpPort;
+
+    @JsonProperty("is_alive")
+    public boolean isAlive;
+
+    public String getIp() {
+      return ip;
     }
 
-    public void setRows(List<BackendRowV2> rows) {
-        this.backends = rows;
+    public void setIp(String ip) {
+      this.ip = ip;
     }
 
-    public static class BackendRowV2 {
-        @JsonProperty("ip")
-        public String ip;
-        @JsonProperty("http_port")
-        public int httpPort;
-        @JsonProperty("is_alive")
-        public boolean isAlive;
-
-        public String getIp() {
-            return ip;
-        }
-
-        public void setIp(String ip) {
-            this.ip = ip;
-        }
-
-        public int getHttpPort() {
-            return httpPort;
-        }
-
-        public void setHttpPort(int httpPort) {
-            this.httpPort = httpPort;
-        }
-
-        public boolean isAlive() {
-            return isAlive;
-        }
-
-        public void setAlive(boolean alive) {
-            isAlive = alive;
-        }
+    public int getHttpPort() {
+      return httpPort;
     }
+
+    public void setHttpPort(int httpPort) {
+      this.httpPort = httpPort;
+    }
+
+    public boolean isAlive() {
+      return isAlive;
+    }
+
+    public void setAlive(boolean alive) {
+      isAlive = alive;
+    }
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Field.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Field.java
@@ -20,102 +20,111 @@ package org.apache.doris.spark.rest.models;
 import java.util.Objects;
 
 public class Field {
-    private String name;
-    private String type;
-    private String comment;
-    private int precision;
-    private int scale;
+  private String name;
+  private String type;
+  private String comment;
+  private int precision;
+  private int scale;
 
-    private String aggregation_type;
+  private String aggregation_type;
 
-    public Field() { }
+  public Field() {}
 
-    public Field(String name, String type, String comment, int precision, int scale, String aggregation_type) {
-        this.name = name;
-        this.type = type;
-        this.comment = comment;
-        this.precision = precision;
-        this.scale = scale;
-        this.aggregation_type = aggregation_type;
+  public Field(
+      String name, String type, String comment, int precision, int scale, String aggregation_type) {
+    this.name = name;
+    this.type = type;
+    this.comment = comment;
+    this.precision = precision;
+    this.scale = scale;
+    this.aggregation_type = aggregation_type;
+  }
+
+  public String getAggregation_type() {
+    return aggregation_type;
+  }
+
+  public void setAggregation_type(String aggregation_type) {
+    this.aggregation_type = aggregation_type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
+  }
+
+  public int getPrecision() {
+    return precision;
+  }
+
+  public void setPrecision(int precision) {
+    this.precision = precision;
+  }
+
+  public int getScale() {
+    return scale;
+  }
+
+  public void setScale(int scale) {
+    this.scale = scale;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
-
-    public String getAggregation_type() {
-        return aggregation_type;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
     }
+    Field field = (Field) o;
+    return precision == field.precision
+        && scale == field.scale
+        && Objects.equals(name, field.name)
+        && Objects.equals(type, field.type)
+        && Objects.equals(comment, field.comment);
+  }
 
-    public void setAggregation_type(String aggregation_type) {
-        this.aggregation_type = aggregation_type;
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, comment, precision, scale);
+  }
 
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    public int getPrecision() {
-        return precision;
-    }
-
-    public void setPrecision(int precision) {
-        this.precision = precision;
-    }
-
-    public int getScale() {
-        return scale;
-    }
-
-    public void setScale(int scale) {
-        this.scale = scale;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Field field = (Field) o;
-        return precision == field.precision &&
-                scale == field.scale &&
-                Objects.equals(name, field.name) &&
-                Objects.equals(type, field.type) &&
-                Objects.equals(comment, field.comment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, type, comment, precision, scale);
-    }
-
-    @Override
-    public String toString() {
-        return "Field{" +
-                "name='" + name + '\'' +
-                ", type='" + type + '\'' +
-                ", comment='" + comment + '\'' +
-                ", precision=" + precision +
-                ", scale=" + scale +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "Field{"
+        + "name='"
+        + name
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", comment='"
+        + comment
+        + '\''
+        + ", precision="
+        + precision
+        + ", scale="
+        + scale
+        + '}';
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/QueryPlan.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/QueryPlan.java
@@ -21,50 +21,50 @@ import java.util.Map;
 import java.util.Objects;
 
 public class QueryPlan {
-    private int status;
-    private String opaqued_query_plan;
-    private Map<String, Tablet> partitions;
+  private int status;
+  private String opaqued_query_plan;
+  private Map<String, Tablet> partitions;
 
-    public int getStatus() {
-        return status;
-    }
+  public int getStatus() {
+    return status;
+  }
 
-    public void setStatus(int status) {
-        this.status = status;
-    }
+  public void setStatus(int status) {
+    this.status = status;
+  }
 
-    public String getOpaqued_query_plan() {
-        return opaqued_query_plan;
-    }
+  public String getOpaqued_query_plan() {
+    return opaqued_query_plan;
+  }
 
-    public void setOpaqued_query_plan(String opaqued_query_plan) {
-        this.opaqued_query_plan = opaqued_query_plan;
-    }
+  public void setOpaqued_query_plan(String opaqued_query_plan) {
+    this.opaqued_query_plan = opaqued_query_plan;
+  }
 
-    public Map<String, Tablet> getPartitions() {
-        return partitions;
-    }
+  public Map<String, Tablet> getPartitions() {
+    return partitions;
+  }
 
-    public void setPartitions(Map<String, Tablet> partitions) {
-        this.partitions = partitions;
-    }
+  public void setPartitions(Map<String, Tablet> partitions) {
+    this.partitions = partitions;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        QueryPlan queryPlan = (QueryPlan) o;
-        return status == queryPlan.status &&
-                Objects.equals(opaqued_query_plan, queryPlan.opaqued_query_plan) &&
-                Objects.equals(partitions, queryPlan.partitions);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueryPlan queryPlan = (QueryPlan) o;
+    return status == queryPlan.status
+        && Objects.equals(opaqued_query_plan, queryPlan.opaqued_query_plan)
+        && Objects.equals(partitions, queryPlan.partitions);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(status, opaqued_query_plan, partitions);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, opaqued_query_plan, partitions);
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/RespContent.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/RespContent.java
@@ -24,73 +24,72 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RespContent {
 
-    @JsonProperty(value = "TxnId")
-    private int TxnId;
+  @JsonProperty(value = "TxnId")
+  private int TxnId;
 
-    @JsonProperty(value = "Label")
-    private String Label;
+  @JsonProperty(value = "Label")
+  private String Label;
 
-    @JsonProperty(value = "Status")
-    private String Status;
+  @JsonProperty(value = "Status")
+  private String Status;
 
-    @JsonProperty(value = "ExistingJobStatus")
-    private String ExistingJobStatus;
+  @JsonProperty(value = "ExistingJobStatus")
+  private String ExistingJobStatus;
 
-    @JsonProperty(value = "Message")
-    private String Message;
+  @JsonProperty(value = "Message")
+  private String Message;
 
-    @JsonProperty(value = "NumberTotalRows")
-    private long NumberTotalRows;
+  @JsonProperty(value = "NumberTotalRows")
+  private long NumberTotalRows;
 
-    @JsonProperty(value = "NumberLoadedRows")
-    private long NumberLoadedRows;
+  @JsonProperty(value = "NumberLoadedRows")
+  private long NumberLoadedRows;
 
-    @JsonProperty(value = "NumberFilteredRows")
-    private int NumberFilteredRows;
+  @JsonProperty(value = "NumberFilteredRows")
+  private int NumberFilteredRows;
 
-    @JsonProperty(value = "NumberUnselectedRows")
-    private int NumberUnselectedRows;
+  @JsonProperty(value = "NumberUnselectedRows")
+  private int NumberUnselectedRows;
 
-    @JsonProperty(value = "LoadBytes")
-    private long LoadBytes;
+  @JsonProperty(value = "LoadBytes")
+  private long LoadBytes;
 
-    @JsonProperty(value = "LoadTimeMs")
-    private int LoadTimeMs;
+  @JsonProperty(value = "LoadTimeMs")
+  private int LoadTimeMs;
 
-    @JsonProperty(value = "BeginTxnTimeMs")
-    private int BeginTxnTimeMs;
+  @JsonProperty(value = "BeginTxnTimeMs")
+  private int BeginTxnTimeMs;
 
-    @JsonProperty(value = "StreamLoadPutTimeMs")
-    private int StreamLoadPutTimeMs;
+  @JsonProperty(value = "StreamLoadPutTimeMs")
+  private int StreamLoadPutTimeMs;
 
-    @JsonProperty(value = "ReadDataTimeMs")
-    private int ReadDataTimeMs;
+  @JsonProperty(value = "ReadDataTimeMs")
+  private int ReadDataTimeMs;
 
-    @JsonProperty(value = "WriteDataTimeMs")
-    private int WriteDataTimeMs;
+  @JsonProperty(value = "WriteDataTimeMs")
+  private int WriteDataTimeMs;
 
-    @JsonProperty(value = "CommitAndPublishTimeMs")
-    private int CommitAndPublishTimeMs;
+  @JsonProperty(value = "CommitAndPublishTimeMs")
+  private int CommitAndPublishTimeMs;
 
-    @JsonProperty(value = "ErrorURL")
-    private String ErrorURL;
+  @JsonProperty(value = "ErrorURL")
+  private String ErrorURL;
 
-    public String getStatus() {
-        return Status;
+  public String getStatus() {
+    return Status;
+  }
+
+  public String getMessage() {
+    return Message;
+  }
+
+  @Override
+  public String toString() {
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      return mapper.writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      return "";
     }
-
-    public String getMessage() {
-        return Message;
-    }
-
-    @Override
-    public String toString() {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
-            return "";
-        }
-
-    }
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Schema.java
@@ -22,85 +22,88 @@ import java.util.List;
 import java.util.Objects;
 
 public class Schema {
-    private int status = 0;
-    private String keysType;
-    private List<Field> properties;
+  private int status = 0;
+  private String keysType;
+  private List<Field> properties;
 
-    public Schema() {
-        properties = new ArrayList<>();
-    }
+  public Schema() {
+    properties = new ArrayList<>();
+  }
 
-    public Schema(int fieldCount) {
-        properties = new ArrayList<>(fieldCount);
-    }
+  public Schema(int fieldCount) {
+    properties = new ArrayList<>(fieldCount);
+  }
 
-    public int getStatus() {
-        return status;
-    }
+  public int getStatus() {
+    return status;
+  }
 
-    public void setStatus(int status) {
-        this.status = status;
-    }
+  public void setStatus(int status) {
+    this.status = status;
+  }
 
-    public String getKeysType() {
-        return keysType;
-    }
+  public String getKeysType() {
+    return keysType;
+  }
 
-    public void setKeysType(String keysType) {
-        this.keysType = keysType;
-    }
+  public void setKeysType(String keysType) {
+    this.keysType = keysType;
+  }
 
-    public List<Field> getProperties() {
-        return properties;
-    }
+  public List<Field> getProperties() {
+    return properties;
+  }
 
-    public void setProperties(List<Field> properties) {
-        this.properties = properties;
-    }
+  public void setProperties(List<Field> properties) {
+    this.properties = properties;
+  }
 
-    public void put(String name, String type, String comment, int scale, int precision, String aggregation_type) {
-        properties.add(new Field(name, type, comment, scale, precision, aggregation_type));
-    }
+  public void put(
+      String name, String type, String comment, int scale, int precision, String aggregation_type) {
+    properties.add(new Field(name, type, comment, scale, precision, aggregation_type));
+  }
 
-    public void put(Field f) {
-        properties.add(f);
-    }
+  public void put(Field f) {
+    properties.add(f);
+  }
 
-    public Field get(int index) {
-        if (index >= properties.size()) {
-            throw new IndexOutOfBoundsException("Index: " + index + ", Fields size：" + properties.size());
-        }
-        return properties.get(index);
+  public Field get(int index) {
+    if (index >= properties.size()) {
+      throw new IndexOutOfBoundsException("Index: " + index + ", Fields size：" + properties.size());
     }
+    return properties.get(index);
+  }
 
-    public int size() {
-        return properties.size();
-    }
+  public int size() {
+    return properties.size();
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Schema schema = (Schema) o;
-        return status == schema.status &&
-                Objects.equals(properties, schema.properties);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Schema schema = (Schema) o;
+    return status == schema.status && Objects.equals(properties, schema.properties);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(status, properties);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, properties);
+  }
 
-    @Override
-    public String toString() {
-        return "Schema{" +
-                "status=" + status +
-                ", keysType='" + keysType +
-                ", properties=" + properties +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "Schema{"
+        + "status="
+        + status
+        + ", keysType='"
+        + keysType
+        + ", properties="
+        + properties
+        + '}';
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Tablet.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/Tablet.java
@@ -21,60 +21,60 @@ import java.util.List;
 import java.util.Objects;
 
 public class Tablet {
-    private List<String> routings;
-    private int version;
-    private long versionHash;
-    private long schemaHash;
+  private List<String> routings;
+  private int version;
+  private long versionHash;
+  private long schemaHash;
 
-    public List<String> getRoutings() {
-        return routings;
-    }
+  public List<String> getRoutings() {
+    return routings;
+  }
 
-    public void setRoutings(List<String> routings) {
-        this.routings = routings;
-    }
+  public void setRoutings(List<String> routings) {
+    this.routings = routings;
+  }
 
-    public int getVersion() {
-        return version;
-    }
+  public int getVersion() {
+    return version;
+  }
 
-    public void setVersion(int version) {
-        this.version = version;
-    }
+  public void setVersion(int version) {
+    this.version = version;
+  }
 
-    public long getVersionHash() {
-        return versionHash;
-    }
+  public long getVersionHash() {
+    return versionHash;
+  }
 
-    public void setVersionHash(long versionHash) {
-        this.versionHash = versionHash;
-    }
+  public void setVersionHash(long versionHash) {
+    this.versionHash = versionHash;
+  }
 
-    public long getSchemaHash() {
-        return schemaHash;
-    }
+  public long getSchemaHash() {
+    return schemaHash;
+  }
 
-    public void setSchemaHash(long schemaHash) {
-        this.schemaHash = schemaHash;
-    }
+  public void setSchemaHash(long schemaHash) {
+    this.schemaHash = schemaHash;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Tablet tablet = (Tablet) o;
-        return version == tablet.version &&
-                versionHash == tablet.versionHash &&
-                schemaHash == tablet.schemaHash &&
-                Objects.equals(routings, tablet.routings);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Tablet tablet = (Tablet) o;
+    return version == tablet.version
+        && versionHash == tablet.versionHash
+        && schemaHash == tablet.schemaHash
+        && Objects.equals(routings, tablet.routings);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(routings, version, versionHash, schemaHash);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(routings, version, versionHash, schemaHash);
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/Routing.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/Routing.java
@@ -23,48 +23,43 @@ import org.apache.doris.spark.exception.IllegalArgumentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * present an Doris BE address.
- */
+/** present an Doris BE address. */
 public class Routing {
-    private final static Logger logger = LoggerFactory.getLogger(Routing.class);
+  private static final Logger logger = LoggerFactory.getLogger(Routing.class);
 
-    private String host;
-    private int port;
+  private String host;
+  private int port;
 
-    public Routing(String routing) throws IllegalArgumentException {
-        parseRouting(routing);
+  public Routing(String routing) throws IllegalArgumentException {
+    parseRouting(routing);
+  }
+
+  private void parseRouting(String routing) throws IllegalArgumentException {
+    logger.debug("Parse Doris BE address: '{}'.", routing);
+    String[] hostPort = routing.split(":");
+    if (hostPort.length != 2) {
+      logger.error("Format of Doris BE address '{}' is illegal.", routing);
+      throw new IllegalArgumentException("Doris BE", routing);
     }
-
-    private void parseRouting(String routing) throws IllegalArgumentException {
-        logger.debug("Parse Doris BE address: '{}'.", routing);
-        String[] hostPort = routing.split(":");
-        if (hostPort.length != 2) {
-            logger.error("Format of Doris BE address '{}' is illegal.", routing);
-            throw new IllegalArgumentException("Doris BE", routing);
-        }
-        this.host = hostPort[0];
-        try {
-            this.port = Integer.parseInt(hostPort[1]);
-        } catch (NumberFormatException e) {
-            logger.error(PARSE_NUMBER_FAILED_MESSAGE, "Doris BE's port", hostPort[1]);
-            throw new IllegalArgumentException("Doris BE", routing);
-        }
+    this.host = hostPort[0];
+    try {
+      this.port = Integer.parseInt(hostPort[1]);
+    } catch (NumberFormatException e) {
+      logger.error(PARSE_NUMBER_FAILED_MESSAGE, "Doris BE's port", hostPort[1]);
+      throw new IllegalArgumentException("Doris BE", routing);
     }
+  }
 
-    public String getHost() {
-        return host;
-    }
+  public String getHost() {
+    return host;
+  }
 
-    public int getPort() {
-        return port;
-    }
+  public int getPort() {
+    return port;
+  }
 
-    @Override
-    public String toString() {
-        return "Doris BE{" +
-                "host='" + host + '\'' +
-                ", port=" + port +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "Doris BE{" + "host='" + host + '\'' + ", port=" + port + '}';
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.spark.serialization;
 
+import com.google.common.base.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -24,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -48,287 +48,287 @@ import org.apache.spark.sql.types.Decimal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-
-/**
- * row batch data container.
- */
+/** row batch data container. */
 public class RowBatch {
-    private static final Logger logger = LoggerFactory.getLogger(RowBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(RowBatch.class);
 
-    public static class Row {
-        private final List<Object> cols;
+  public static class Row {
+    private final List<Object> cols;
 
-        Row(int colCount) {
-            this.cols = new ArrayList<>(colCount);
-        }
-
-        List<Object> getCols() {
-            return cols;
-        }
-
-        public void put(Object o) {
-            cols.add(o);
-        }
+    Row(int colCount) {
+      this.cols = new ArrayList<>(colCount);
     }
 
-    // offset for iterate the rowBatch
-    private int offsetInRowBatch = 0;
-    private int rowCountInOneBatch = 0;
-    private int readRowCount = 0;
-    private final List<Row> rowBatch = new ArrayList<>();
-    private final ArrowStreamReader arrowStreamReader;
-    private List<FieldVector> fieldVectors;
-    private final RootAllocator rootAllocator;
-    private final Schema schema;
+    List<Object> getCols() {
+      return cols;
+    }
 
-    public RowBatch(TScanBatchResult nextResult, Schema schema) throws DorisException {
-        this.schema = schema;
-        this.rootAllocator = new RootAllocator(Integer.MAX_VALUE);
-        this.arrowStreamReader = new ArrowStreamReader(
-                new ByteArrayInputStream(nextResult.getRows()),
-                rootAllocator
-        );
-        try {
-            VectorSchemaRoot root = arrowStreamReader.getVectorSchemaRoot();
-            while (arrowStreamReader.loadNextBatch()) {
-                fieldVectors = root.getFieldVectors();
-                if (fieldVectors.size() != schema.size()) {
-                    logger.error("Schema size '{}' is not equal to arrow field size '{}'.",
-                            fieldVectors.size(), schema.size());
-                    throw new DorisException("Load Doris data failed, schema size of fetch data is wrong.");
-                }
-                if (fieldVectors.size() == 0 || root.getRowCount() == 0) {
-                    logger.debug("One batch in arrow has no data.");
-                    continue;
-                }
-                rowCountInOneBatch = root.getRowCount();
-                // init the rowBatch
-                for (int i = 0; i < rowCountInOneBatch; ++i) {
-                    rowBatch.add(new Row(fieldVectors.size()));
-                }
-                convertArrowToRowBatch();
-                readRowCount += root.getRowCount();
+    public void put(Object o) {
+      cols.add(o);
+    }
+  }
+
+  // offset for iterate the rowBatch
+  private int offsetInRowBatch = 0;
+  private int rowCountInOneBatch = 0;
+  private int readRowCount = 0;
+  private final List<Row> rowBatch = new ArrayList<>();
+  private final ArrowStreamReader arrowStreamReader;
+  private List<FieldVector> fieldVectors;
+  private final RootAllocator rootAllocator;
+  private final Schema schema;
+
+  public RowBatch(TScanBatchResult nextResult, Schema schema) throws DorisException {
+    this.schema = schema;
+    this.rootAllocator = new RootAllocator(Integer.MAX_VALUE);
+    this.arrowStreamReader =
+        new ArrowStreamReader(new ByteArrayInputStream(nextResult.getRows()), rootAllocator);
+    try {
+      VectorSchemaRoot root = arrowStreamReader.getVectorSchemaRoot();
+      while (arrowStreamReader.loadNextBatch()) {
+        fieldVectors = root.getFieldVectors();
+        if (fieldVectors.size() != schema.size()) {
+          logger.error(
+              "Schema size '{}' is not equal to arrow field size '{}'.",
+              fieldVectors.size(),
+              schema.size());
+          throw new DorisException("Load Doris data failed, schema size of fetch data is wrong.");
+        }
+        if (fieldVectors.size() == 0 || root.getRowCount() == 0) {
+          logger.debug("One batch in arrow has no data.");
+          continue;
+        }
+        rowCountInOneBatch = root.getRowCount();
+        // init the rowBatch
+        for (int i = 0; i < rowCountInOneBatch; ++i) {
+          rowBatch.add(new Row(fieldVectors.size()));
+        }
+        convertArrowToRowBatch();
+        readRowCount += root.getRowCount();
+      }
+    } catch (Exception e) {
+      logger.error("Read Doris Data failed because: ", e);
+      throw new DorisException(e.getMessage());
+    } finally {
+      close();
+    }
+  }
+
+  public boolean hasNext() {
+    return offsetInRowBatch < readRowCount;
+  }
+
+  private void addValueToRow(int rowIndex, Object obj) {
+    if (rowIndex > rowCountInOneBatch) {
+      String errMsg =
+          "Get row offset: " + rowIndex + " larger than row size: " + rowCountInOneBatch;
+      logger.error(errMsg);
+      throw new NoSuchElementException(errMsg);
+    }
+    rowBatch.get(readRowCount + rowIndex).put(obj);
+  }
+
+  public void convertArrowToRowBatch() throws DorisException {
+    try {
+      for (int col = 0; col < fieldVectors.size(); col++) {
+        FieldVector curFieldVector = fieldVectors.get(col);
+        Types.MinorType mt = curFieldVector.getMinorType();
+
+        final String currentType = schema.get(col).getType();
+        switch (currentType) {
+          case "NULL_TYPE":
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              addValueToRow(rowIndex, null);
             }
-        } catch (Exception e) {
-            logger.error("Read Doris Data failed because: ", e);
-            throw new DorisException(e.getMessage());
-        } finally {
-            close();
-        }
-    }
-
-    public boolean hasNext() {
-        return offsetInRowBatch < readRowCount;
-    }
-
-    private void addValueToRow(int rowIndex, Object obj) {
-        if (rowIndex > rowCountInOneBatch) {
-            String errMsg = "Get row offset: " + rowIndex + " larger than row size: " +
-                    rowCountInOneBatch;
+            break;
+          case "BOOLEAN":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.BIT), typeMismatchMessage(currentType, mt));
+            BitVector bitVector = (BitVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue = bitVector.isNull(rowIndex) ? null : bitVector.get(rowIndex) != 0;
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "TINYINT":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.TINYINT), typeMismatchMessage(currentType, mt));
+            TinyIntVector tinyIntVector = (TinyIntVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue =
+                  tinyIntVector.isNull(rowIndex) ? null : tinyIntVector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "SMALLINT":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.SMALLINT), typeMismatchMessage(currentType, mt));
+            SmallIntVector smallIntVector = (SmallIntVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue =
+                  smallIntVector.isNull(rowIndex) ? null : smallIntVector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "INT":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.INT), typeMismatchMessage(currentType, mt));
+            IntVector intVector = (IntVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue = intVector.isNull(rowIndex) ? null : intVector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "BIGINT":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.BIGINT), typeMismatchMessage(currentType, mt));
+            BigIntVector bigIntVector = (BigIntVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue = bigIntVector.isNull(rowIndex) ? null : bigIntVector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "FLOAT":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.FLOAT4), typeMismatchMessage(currentType, mt));
+            Float4Vector float4Vector = (Float4Vector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue = float4Vector.isNull(rowIndex) ? null : float4Vector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "TIME":
+          case "DOUBLE":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.FLOAT8), typeMismatchMessage(currentType, mt));
+            Float8Vector float8Vector = (Float8Vector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue = float8Vector.isNull(rowIndex) ? null : float8Vector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "BINARY":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.VARBINARY), typeMismatchMessage(currentType, mt));
+            VarBinaryVector varBinaryVector = (VarBinaryVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              Object fieldValue =
+                  varBinaryVector.isNull(rowIndex) ? null : varBinaryVector.get(rowIndex);
+              addValueToRow(rowIndex, fieldValue);
+            }
+            break;
+          case "DECIMAL":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.VARCHAR), typeMismatchMessage(currentType, mt));
+            VarCharVector varCharVectorForDecimal = (VarCharVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              if (varCharVectorForDecimal.isNull(rowIndex)) {
+                addValueToRow(rowIndex, null);
+                continue;
+              }
+              String decimalValue = new String(varCharVectorForDecimal.get(rowIndex));
+              Decimal decimal = new Decimal();
+              try {
+                decimal.set(new scala.math.BigDecimal(new BigDecimal(decimalValue)));
+              } catch (NumberFormatException e) {
+                String errMsg = "Decimal response result '" + decimalValue + "' is illegal.";
+                logger.error(errMsg, e);
+                throw new DorisException(errMsg);
+              }
+              addValueToRow(rowIndex, decimal);
+            }
+            break;
+          case "DECIMALV2":
+          case "DECIMAL32":
+          case "DECIMAL64":
+          case "DECIMAL128I":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.DECIMAL), typeMismatchMessage(currentType, mt));
+            DecimalVector decimalVector = (DecimalVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              if (decimalVector.isNull(rowIndex)) {
+                addValueToRow(rowIndex, null);
+                continue;
+              }
+              Decimal decimalV2 = Decimal.apply(decimalVector.getObject(rowIndex));
+              addValueToRow(rowIndex, decimalV2);
+            }
+            break;
+          case "DATE":
+          case "DATEV2":
+          case "DATETIME":
+          case "DATETIMEV2":
+          case "LARGEINT":
+          case "CHAR":
+          case "VARCHAR":
+          case "STRING":
+          case "JSONB":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.VARCHAR), typeMismatchMessage(currentType, mt));
+            VarCharVector varCharVector = (VarCharVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              if (varCharVector.isNull(rowIndex)) {
+                addValueToRow(rowIndex, null);
+                continue;
+              }
+              String value = new String(varCharVector.get(rowIndex), StandardCharsets.UTF_8);
+              addValueToRow(rowIndex, value);
+            }
+            break;
+          case "ARRAY":
+            Preconditions.checkArgument(
+                mt.equals(Types.MinorType.LIST), typeMismatchMessage(currentType, mt));
+            ListVector listVector = (ListVector) curFieldVector;
+            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+              if (listVector.isNull(rowIndex)) {
+                addValueToRow(rowIndex, null);
+                continue;
+              }
+              String value = listVector.getObject(rowIndex).toString();
+              addValueToRow(rowIndex, value);
+            }
+            break;
+          default:
+            String errMsg = "Unsupported type " + schema.get(col).getType();
             logger.error(errMsg);
-            throw new NoSuchElementException(errMsg);
+            throw new DorisException(errMsg);
         }
-        rowBatch.get(readRowCount + rowIndex).put(obj);
+      }
+    } catch (Exception e) {
+      close();
+      throw e;
     }
+  }
 
-    public void convertArrowToRowBatch() throws DorisException {
-        try {
-            for (int col = 0; col < fieldVectors.size(); col++) {
-                FieldVector curFieldVector = fieldVectors.get(col);
-                Types.MinorType mt = curFieldVector.getMinorType();
-
-                final String currentType = schema.get(col).getType();
-                switch (currentType) {
-                    case "NULL_TYPE":
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            addValueToRow(rowIndex, null);
-                        }
-                        break;
-                    case "BOOLEAN":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.BIT),
-                                typeMismatchMessage(currentType, mt));
-                        BitVector bitVector = (BitVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = bitVector.isNull(rowIndex) ? null : bitVector.get(rowIndex) != 0;
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "TINYINT":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.TINYINT),
-                                typeMismatchMessage(currentType, mt));
-                        TinyIntVector tinyIntVector = (TinyIntVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = tinyIntVector.isNull(rowIndex) ? null : tinyIntVector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "SMALLINT":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.SMALLINT),
-                                typeMismatchMessage(currentType, mt));
-                        SmallIntVector smallIntVector = (SmallIntVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = smallIntVector.isNull(rowIndex) ? null : smallIntVector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "INT":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.INT),
-                                typeMismatchMessage(currentType, mt));
-                        IntVector intVector = (IntVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = intVector.isNull(rowIndex) ? null : intVector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "BIGINT":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.BIGINT),
-                                typeMismatchMessage(currentType, mt));
-                        BigIntVector bigIntVector = (BigIntVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = bigIntVector.isNull(rowIndex) ? null : bigIntVector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "FLOAT":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.FLOAT4),
-                                typeMismatchMessage(currentType, mt));
-                        Float4Vector float4Vector = (Float4Vector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = float4Vector.isNull(rowIndex) ? null : float4Vector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "TIME":
-                    case "DOUBLE":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.FLOAT8),
-                                typeMismatchMessage(currentType, mt));
-                        Float8Vector float8Vector = (Float8Vector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = float8Vector.isNull(rowIndex) ? null : float8Vector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "BINARY":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.VARBINARY),
-                                typeMismatchMessage(currentType, mt));
-                        VarBinaryVector varBinaryVector = (VarBinaryVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = varBinaryVector.isNull(rowIndex) ? null : varBinaryVector.get(rowIndex);
-                            addValueToRow(rowIndex, fieldValue);
-                        }
-                        break;
-                    case "DECIMAL":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.VARCHAR),
-                                typeMismatchMessage(currentType, mt));
-                        VarCharVector varCharVectorForDecimal = (VarCharVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            if (varCharVectorForDecimal.isNull(rowIndex)) {
-                                addValueToRow(rowIndex, null);
-                                continue;
-                            }
-                            String decimalValue = new String(varCharVectorForDecimal.get(rowIndex));
-                            Decimal decimal = new Decimal();
-                            try {
-                                decimal.set(new scala.math.BigDecimal(new BigDecimal(decimalValue)));
-                            } catch (NumberFormatException e) {
-                                String errMsg = "Decimal response result '" + decimalValue + "' is illegal.";
-                                logger.error(errMsg, e);
-                                throw new DorisException(errMsg);
-                            }
-                            addValueToRow(rowIndex, decimal);
-                        }
-                        break;
-                    case "DECIMALV2":
-                    case "DECIMAL32":
-                    case "DECIMAL64":
-                    case "DECIMAL128I":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.DECIMAL),
-                                typeMismatchMessage(currentType, mt));
-                        DecimalVector decimalVector = (DecimalVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            if (decimalVector.isNull(rowIndex)) {
-                                addValueToRow(rowIndex, null);
-                                continue;
-                            }
-                            Decimal decimalV2 = Decimal.apply(decimalVector.getObject(rowIndex));
-                            addValueToRow(rowIndex, decimalV2);
-                        }
-                        break;
-                    case "DATE":
-                    case "DATEV2":
-                    case "DATETIME":
-                    case "DATETIMEV2":
-                    case "LARGEINT":
-                    case "CHAR":
-                    case "VARCHAR":
-                    case "STRING":
-                    case "JSONB":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.VARCHAR),
-                                typeMismatchMessage(currentType, mt));
-                        VarCharVector varCharVector = (VarCharVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            if (varCharVector.isNull(rowIndex)) {
-                                addValueToRow(rowIndex, null);
-                                continue;
-                            }
-                            String value = new String(varCharVector.get(rowIndex), StandardCharsets.UTF_8);
-                            addValueToRow(rowIndex, value);
-                        }
-                        break;
-                    case "ARRAY":
-                        Preconditions.checkArgument(mt.equals(Types.MinorType.LIST),
-                                typeMismatchMessage(currentType, mt));
-                        ListVector listVector = (ListVector) curFieldVector;
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            if (listVector.isNull(rowIndex)) {
-                                addValueToRow(rowIndex, null);
-                                continue;
-                            }
-                            String value = listVector.getObject(rowIndex).toString();
-                            addValueToRow(rowIndex, value);
-                        }
-                        break;
-                    default:
-                        String errMsg = "Unsupported type " + schema.get(col).getType();
-                        logger.error(errMsg);
-                        throw new DorisException(errMsg);
-                }
-            }
-        } catch (Exception e) {
-            close();
-            throw e;
-        }
+  public List<Object> next() {
+    if (!hasNext()) {
+      String errMsg =
+          "Get row offset:" + offsetInRowBatch + " larger than row size: " + readRowCount;
+      logger.error(errMsg);
+      throw new NoSuchElementException(errMsg);
     }
+    return rowBatch.get(offsetInRowBatch++).getCols();
+  }
 
-    public List<Object> next() {
-        if (!hasNext()) {
-            String errMsg = "Get row offset:" + offsetInRowBatch + " larger than row size: " + readRowCount;
-            logger.error(errMsg);
-            throw new NoSuchElementException(errMsg);
-        }
-        return rowBatch.get(offsetInRowBatch++).getCols();
-    }
+  private String typeMismatchMessage(final String sparkType, final Types.MinorType arrowType) {
+    final String messageTemplate = "Spark type is %1$s, but arrow type is %2$s.";
+    return String.format(messageTemplate, sparkType, arrowType.name());
+  }
 
-    private String typeMismatchMessage(final String sparkType, final Types.MinorType arrowType) {
-        final String messageTemplate = "Spark type is %1$s, but arrow type is %2$s.";
-        return String.format(messageTemplate, sparkType, arrowType.name());
-    }
+  public int getReadRowCount() {
+    return readRowCount;
+  }
 
-    public int getReadRowCount() {
-        return readRowCount;
+  public void close() {
+    try {
+      if (arrowStreamReader != null) {
+        arrowStreamReader.close();
+      }
+      if (rootAllocator != null) {
+        rootAllocator.close();
+      }
+    } catch (IOException ioe) {
+      // do nothing
     }
-
-    public void close() {
-        try {
-            if (arrowStreamReader != null) {
-                arrowStreamReader.close();
-            }
-            if (rootAllocator != null) {
-                rootAllocator.close();
-            }
-        } catch (IOException ioe) {
-            // do nothing
-        }
-    }
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ErrorMessages.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ErrorMessages.java
@@ -18,10 +18,13 @@
 package org.apache.doris.spark.util;
 
 public abstract class ErrorMessages {
-    public static final String PARSE_NUMBER_FAILED_MESSAGE = "Parse '{}' to number failed. Original string is '{}'.";
-    public static final String PARSE_BOOL_FAILED_MESSAGE = "Parse '{}' to boolean failed. Original string is '{}'.";
-    public static final String CONNECT_FAILED_MESSAGE = "Connect to doris {} failed.";
-    public static final String ILLEGAL_ARGUMENT_MESSAGE = "argument '{}' is illegal, value is '{}'.";
-    public static final String SHOULD_NOT_HAPPEN_MESSAGE = "Should not come here.";
-    public static final String DORIS_INTERNAL_FAIL_MESSAGE = "Doris server '{}' internal failed, status is '{}', error message is '{}'";
+  public static final String PARSE_NUMBER_FAILED_MESSAGE =
+      "Parse '{}' to number failed. Original string is '{}'.";
+  public static final String PARSE_BOOL_FAILED_MESSAGE =
+      "Parse '{}' to boolean failed. Original string is '{}'.";
+  public static final String CONNECT_FAILED_MESSAGE = "Connect to doris {} failed.";
+  public static final String ILLEGAL_ARGUMENT_MESSAGE = "argument '{}' is illegal, value is '{}'.";
+  public static final String SHOULD_NOT_HAPPEN_MESSAGE = "Should not come here.";
+  public static final String DORIS_INTERNAL_FAIL_MESSAGE =
+      "Doris server '{}' internal failed, status is '{}', error message is '{}'";
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/IOUtils.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/IOUtils.java
@@ -21,31 +21,30 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Properties;
-
 import org.apache.doris.spark.exception.IllegalArgumentException;
 
 public class IOUtils {
-    public static String propsToString(Properties props) throws IllegalArgumentException {
-        StringWriter sw = new StringWriter();
-        if (props != null) {
-            try {
-                props.store(sw, "");
-            } catch (IOException ex) {
-                throw new IllegalArgumentException("Cannot parse props to String.", ex);
-            }
-        }
-        return sw.toString();
+  public static String propsToString(Properties props) throws IllegalArgumentException {
+    StringWriter sw = new StringWriter();
+    if (props != null) {
+      try {
+        props.store(sw, "");
+      } catch (IOException ex) {
+        throw new IllegalArgumentException("Cannot parse props to String.", ex);
+      }
     }
+    return sw.toString();
+  }
 
-    public static Properties propsFromString(String source) throws IllegalArgumentException {
-        Properties copy = new Properties();
-        if (source != null) {
-            try {
-                copy.load(new StringReader(source));
-            } catch (IOException ex) {
-                throw new IllegalArgumentException("Cannot parse props from String.", ex);
-            }
-        }
-        return copy;
+  public static Properties propsFromString(String source) throws IllegalArgumentException {
+    Properties copy = new Properties();
+    if (source != null) {
+      try {
+        copy.load(new StringReader(source));
+      } catch (IOException ex) {
+        throw new IllegalArgumentException("Cannot parse props from String.", ex);
+      }
     }
+    return copy;
+  }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
@@ -20,50 +20,54 @@ package org.apache.doris.spark.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ListUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(ListUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ListUtils.class);
 
-    public static List<String> getSerializedList(List<Map<Object, Object>> batch) throws JsonProcessingException {
-        List<String> result = new ArrayList<>();
-        divideAndSerialize(batch, result);
-        return result;
-    }
+  public static List<String> getSerializedList(List<Map<Object, Object>> batch)
+      throws JsonProcessingException {
+    List<String> result = new ArrayList<>();
+    divideAndSerialize(batch, result);
+    return result;
+  }
 
-    /***
-     * recursively splits large collections to normal collection and serializes the collection
-     * @param batch
-     * @param result
-     * @throws JsonProcessingException
-     */
-    public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result) throws JsonProcessingException {
-        String serializedResult = (new ObjectMapper()).writeValueAsString(batch);
-        // if an error occurred in the batch call to getBytes ,average divide the batch
-        try {
-            //the "Requested array size exceeds VM limit" exception occurs when the collection is large
-            serializedResult.getBytes("UTF-8");
-            result.add(serializedResult);
-            return;
-        } catch (Throwable error) {
-            LOG.error("getBytes error:{} ,average divide the collection", error);
-        }
-        for (List<Map<Object, Object>> avgSubCollection : getAvgSubCollections(batch)) {
-            divideAndSerialize(avgSubCollection, result);
-        }
+  /**
+   * * recursively splits large collections to normal collection and serializes the collection
+   *
+   * @param batch
+   * @param result
+   * @throws JsonProcessingException
+   */
+  public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result)
+      throws JsonProcessingException {
+    String serializedResult = (new ObjectMapper()).writeValueAsString(batch);
+    // if an error occurred in the batch call to getBytes ,average divide the batch
+    try {
+      // the "Requested array size exceeds VM limit" exception occurs when the collection is large
+      serializedResult.getBytes("UTF-8");
+      result.add(serializedResult);
+      return;
+    } catch (Throwable error) {
+      LOG.error("getBytes error:{} ,average divide the collection", error);
     }
+    for (List<Map<Object, Object>> avgSubCollection : getAvgSubCollections(batch)) {
+      divideAndSerialize(avgSubCollection, result);
+    }
+  }
 
-    /***
-     * average divide the collection
-     * @param values
-     * @return
-     */
-    public static List<List<Map<Object, Object>>> getAvgSubCollections(List<Map<Object, Object>> values) {
-        return Lists.partition(values, (values.size() + 1) / 2);
-    }
+  /**
+   * * average divide the collection
+   *
+   * @param values
+   * @return
+   */
+  public static List<List<Map<Object, Object>>> getAvgSubCollections(
+      List<Map<Object, Object>> values) {
+    return Lists.partition(values, (values.size() + 1) / 2);
+  }
 }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/AbstractDorisRDD.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/AbstractDorisRDD.scala
@@ -22,14 +22,13 @@ import scala.reflect.ClassTag
 
 import org.apache.doris.spark.cfg.SparkSettings
 import org.apache.doris.spark.rest.{PartitionDefinition, RestService}
-
-import org.apache.spark.rdd.RDD
 import org.apache.spark.{Partition, SparkContext}
+import org.apache.spark.rdd.RDD
 
-private[spark] abstract class AbstractDorisRDD[T: ClassTag](
+abstract private[spark] class AbstractDorisRDD[T: ClassTag](
     @transient private var sc: SparkContext,
     val params: Map[String, String] = Map.empty)
-    extends RDD[T](sc, Nil) {
+  extends RDD[T](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
     dorisPartitions.zipWithIndex.map { case (dorisPartition, idx) =>
@@ -60,7 +59,7 @@ private[spark] abstract class AbstractDorisRDD[T: ClassTag](
 }
 
 private[spark] class DorisPartition(rddId: Int, idx: Int, val dorisPartition: PartitionDefinition)
-    extends Partition {
+  extends Partition {
 
   override def hashCode(): Int = 31 * (31 * (31 + rddId) + idx) + dorisPartition.hashCode()
 

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/AbstractDorisRDDIterator.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/AbstractDorisRDDIterator.scala
@@ -20,11 +20,11 @@ package org.apache.doris.spark.rdd
 import org.apache.doris.spark.cfg.ConfigurationOptions.DORIS_VALUE_READER_CLASS
 import org.apache.doris.spark.cfg.Settings
 import org.apache.doris.spark.rest.PartitionDefinition
-import org.apache.spark.util.TaskCompletionListener
 import org.apache.spark.{TaskContext, TaskKilledException}
+import org.apache.spark.util.TaskCompletionListener
 import org.slf4j.{Logger, LoggerFactory}
 
-private[spark] abstract class AbstractDorisRDDIterator[T](
+abstract private[spark] class AbstractDorisRDDIterator[T](
     context: TaskContext,
     partition: PartitionDefinition) extends Iterator[T] {
 
@@ -39,7 +39,9 @@ private[spark] abstract class AbstractDorisRDDIterator[T](
     initReader(settings)
     val valueReaderName = settings.getProperty(DORIS_VALUE_READER_CLASS)
     logger.debug(s"Use value reader '$valueReaderName'.")
-    val cons = Class.forName(valueReaderName).getDeclaredConstructor(classOf[PartitionDefinition], classOf[Settings])
+    val cons = Class.forName(valueReaderName).getDeclaredConstructor(
+      classOf[PartitionDefinition],
+      classOf[Settings])
     cons.newInstance(partition, settings).asInstanceOf[ScalaValueReader]
   }
 

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/DorisSpark.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/DorisSpark.scala
@@ -18,7 +18,6 @@
 package org.apache.doris.spark.rdd
 
 import org.apache.doris.spark.cfg.ConfigurationOptions.{DORIS_FILTER_QUERY, DORIS_TABLE_IDENTIFIER}
-
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/ScalaDorisRDD.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/ScalaDorisRDD.scala
@@ -22,13 +22,12 @@ import scala.reflect.ClassTag
 import org.apache.doris.spark.cfg.ConfigurationOptions.DORIS_VALUE_READER_CLASS
 import org.apache.doris.spark.cfg.Settings
 import org.apache.doris.spark.rest.PartitionDefinition
-
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
 private[spark] class ScalaDorisRDD[T: ClassTag](
     sc: SparkContext,
     params: Map[String, String] = Map.empty)
-    extends AbstractDorisRDD[T](sc, params) {
+  extends AbstractDorisRDD[T](sc, params) {
   override def compute(split: Partition, context: TaskContext): ScalaDorisRDDIterator[T] = {
     new ScalaDorisRDDIterator(context, split.asInstanceOf[DorisPartition].dorisPartition)
   }
@@ -37,7 +36,7 @@ private[spark] class ScalaDorisRDD[T: ClassTag](
 private[spark] class ScalaDorisRDDIterator[T](
     context: TaskContext,
     partition: PartitionDefinition)
-    extends AbstractDorisRDDIterator[T](context, partition) {
+  extends AbstractDorisRDDIterator[T](context, partition) {
 
   override def initReader(settings: Settings) = {
     settings.setProperty(DORIS_VALUE_READER_CLASS, classOf[ScalaValueReader].getName)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -17,29 +17,40 @@
 
 package org.apache.doris.spark.sql
 
-import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}
-import org.apache.doris.spark.sql.DorisWriterOptionKeys.maxRowCount
-import org.apache.doris.spark.{CachedDorisStreamLoadClient, DorisStreamLoad}
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.execution.streaming.Sink
-import org.apache.spark.sql.{DataFrame, Row, SQLContext}
-import org.slf4j.{Logger, LoggerFactory}
-
-import collection.JavaConverters._
 import java.io.IOException
 import java.util
 import java.util.Objects
+
 import scala.util.control.Breaks
 
-private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSettings) extends Sink with Serializable {
+import collection.JavaConverters._
+import org.apache.doris.spark.{CachedDorisStreamLoadClient, DorisStreamLoad}
+import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}
+import org.apache.doris.spark.sql.DorisWriterOptionKeys.maxRowCount
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.execution.streaming.Sink
+import org.slf4j.{Logger, LoggerFactory}
+
+private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSettings) extends Sink
+  with Serializable {
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[DorisStreamLoadSink].getName)
   @volatile private var latestBatchId = -1L
-  val batchSize: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_SIZE, ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
-  val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_MAX_RETRIES, ConfigurationOptions.SINK_MAX_RETRIES_DEFAULT)
-  val sinkTaskPartitionSize = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_TASK_PARTITION_SIZE)
-  val sinkTaskUseRepartition = settings.getProperty(ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION, ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION_DEFAULT.toString).toBoolean
-  val batchInterValMs = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_INTERVAL_MS, ConfigurationOptions.DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT)
+  val batchSize: Int = settings.getIntegerProperty(
+    ConfigurationOptions.DORIS_SINK_BATCH_SIZE,
+    ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
+  val maxRetryTimes: Int = settings.getIntegerProperty(
+    ConfigurationOptions.DORIS_SINK_MAX_RETRIES,
+    ConfigurationOptions.SINK_MAX_RETRIES_DEFAULT)
+  val sinkTaskPartitionSize =
+    settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_TASK_PARTITION_SIZE)
+  val sinkTaskUseRepartition = settings.getProperty(
+    ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION,
+    ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION_DEFAULT.toString).toBoolean
+  val batchInterValMs = settings.getIntegerProperty(
+    ConfigurationOptions.DORIS_SINK_BATCH_INTERVAL_MS,
+    ConfigurationOptions.DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT)
 
   val dorisStreamLoader: DorisStreamLoad = CachedDorisStreamLoadClient.getOrCreate(settings)
 
@@ -55,7 +66,8 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
   def write(rdd: RDD[Row]): Unit = {
     var resultRdd = rdd
     if (Objects.nonNull(sinkTaskPartitionSize)) {
-      resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
+      resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize)
+      else resultRdd.coalesce(sinkTaskPartitionSize)
     }
     resultRdd
       .map(_.toSeq.map(_.asInstanceOf[AnyRef]).toList.asJava)
@@ -67,7 +79,6 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
 
     /**
      * flush data to Doris and do retry when flush error
-     *
      */
     def flush(batch: Iterable[util.List[Object]]): Unit = {
       val loop = new Breaks
@@ -87,10 +98,14 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
               } catch {
                 case ex: InterruptedException =>
                   Thread.currentThread.interrupt()
-                  throw new IOException("unable to flush; interrupted while doing another attempt", ex)
+                  throw new IOException(
+                    "unable to flush; interrupted while doing another attempt",
+                    ex)
               }
           }
-          throw new IOException(s"Failed to load $maxRowCount batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", err)
+          throw new IOException(
+            s"Failed to load $maxRowCount batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.",
+            err)
         }
       }
     }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisWriterOption.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisWriterOption.scala
@@ -18,24 +18,38 @@ package org.apache.doris.spark.sql
 
 import org.apache.doris.spark.exception.DorisException
 
-class DorisWriterOption(val feHostPort: String ,val dbName: String,val tbName: String,
-                        val  user: String ,val password: String,
-                        val maxRowCount: Long,val maxRetryTimes:Int)
+class DorisWriterOption(
+    val feHostPort: String,
+    val dbName: String,
+    val tbName: String,
+    val user: String,
+    val password: String,
+    val maxRowCount: Long,
+    val maxRetryTimes: Int)
 
-object DorisWriterOption{
- def apply(parameters: Map[String, String]): DorisWriterOption={
-  val feHostPort: String = parameters.getOrElse(DorisWriterOptionKeys.feHostPort, throw new DorisException("feHostPort is empty"))
+object DorisWriterOption {
+  def apply(parameters: Map[String, String]): DorisWriterOption = {
+    val feHostPort: String = parameters.getOrElse(
+      DorisWriterOptionKeys.feHostPort,
+      throw new DorisException("feHostPort is empty"))
 
-  val dbName: String = parameters.getOrElse(DorisWriterOptionKeys.dbName, throw new DorisException("dbName is empty"))
+    val dbName: String = parameters.getOrElse(
+      DorisWriterOptionKeys.dbName,
+      throw new DorisException("dbName is empty"))
 
-  val tbName: String = parameters.getOrElse(DorisWriterOptionKeys.tbName, throw new DorisException("tbName is empty"))
+    val tbName: String = parameters.getOrElse(
+      DorisWriterOptionKeys.tbName,
+      throw new DorisException("tbName is empty"))
 
-  val user: String = parameters.getOrElse(DorisWriterOptionKeys.user, throw new DorisException("user is empty"))
+    val user: String =
+      parameters.getOrElse(DorisWriterOptionKeys.user, throw new DorisException("user is empty"))
 
-  val password: String = parameters.getOrElse(DorisWriterOptionKeys.password, throw new DorisException("password is empty"))
+    val password: String = parameters.getOrElse(
+      DorisWriterOptionKeys.password,
+      throw new DorisException("password is empty"))
 
-  val maxRowCount: Long = parameters.getOrElse(DorisWriterOptionKeys.maxRowCount, "1024").toLong
-  val maxRetryTimes: Int = parameters.getOrElse(DorisWriterOptionKeys.maxRetryTimes, "3").toInt
-  new DorisWriterOption(feHostPort, dbName, tbName, user, password, maxRowCount, maxRetryTimes)
- }
+    val maxRowCount: Long = parameters.getOrElse(DorisWriterOptionKeys.maxRowCount, "1024").toLong
+    val maxRetryTimes: Int = parameters.getOrElse(DorisWriterOptionKeys.maxRetryTimes, "3").toInt
+    new DorisWriterOption(feHostPort, dbName, tbName, user, password, maxRowCount, maxRetryTimes)
+  }
 }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisWriterOptionKeys.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisWriterOptionKeys.scala
@@ -17,12 +17,12 @@
 package org.apache.doris.spark.sql
 
 object DorisWriterOptionKeys {
-  val feHostPort="feHostPort"
-  val dbName="dbName"
-  val tbName="tbName"
-  val user="user"
-  val password="password"
-  val maxRowCount="maxRowCount"
-  val maxRetryTimes="maxRetryTimes"
+  val feHostPort = "feHostPort"
+  val dbName = "dbName"
+  val tbName = "tbName"
+  val user = "user"
+  val password = "password"
+  val maxRowCount = "maxRowCount"
+  val maxRetryTimes = "maxRetryTimes"
 
 }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/ScalaDorisRow.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/ScalaDorisRow.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.sql.Row
 
 private[spark] class ScalaDorisRow(rowOrder: Seq[String]) extends Row {
-   lazy val values: ArrayBuffer[Any] = ArrayBuffer.fill(rowOrder.size)(null)
+  lazy val values: ArrayBuffer[Any] = ArrayBuffer.fill(rowOrder.size)(null)
 
   /** No-arg constructor for Kryo serialization. */
   def this() = this(null)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/ScalaDorisRowRDD.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/ScalaDorisRowRDD.scala
@@ -21,15 +21,14 @@ import org.apache.doris.spark.cfg.ConfigurationOptions.DORIS_VALUE_READER_CLASS
 import org.apache.doris.spark.cfg.Settings
 import org.apache.doris.spark.rdd.{AbstractDorisRDD, AbstractDorisRDDIterator, DorisPartition}
 import org.apache.doris.spark.rest.PartitionDefinition
-
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.StructType
 
 private[spark] class ScalaDorisRowRDD(
-  sc: SparkContext,
-  params: Map[String, String] = Map.empty,
-  struct: StructType)
+    sc: SparkContext,
+    params: Map[String, String] = Map.empty,
+    struct: StructType)
   extends AbstractDorisRDD[Row](sc, params) {
 
   override def compute(split: Partition, context: TaskContext): ScalaDorisRowRDDIterator = {
@@ -38,9 +37,9 @@ private[spark] class ScalaDorisRowRDD(
 }
 
 private[spark] class ScalaDorisRowRDDIterator(
-  context: TaskContext,
-  partition: PartitionDefinition,
-  struct: StructType)
+    context: TaskContext,
+    partition: PartitionDefinition,
+    struct: StructType)
   extends AbstractDorisRDDIterator[Row](context, partition) {
 
   override def initReader(settings: Settings) = {

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/ScalaDorisRowValueReader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/ScalaDorisRowValueReader.scala
@@ -18,6 +18,7 @@
 package org.apache.doris.spark.sql
 
 import scala.collection.JavaConverters._
+
 import org.apache.doris.spark.cfg.ConfigurationOptions.DORIS_READ_FIELD
 import org.apache.doris.spark.cfg.Settings
 import org.apache.doris.spark.exception.ShouldNeverHappenException
@@ -27,8 +28,8 @@ import org.apache.doris.spark.util.ErrorMessages.SHOULD_NOT_HAPPEN_MESSAGE
 import org.slf4j.{Logger, LoggerFactory}
 
 class ScalaDorisRowValueReader(
-  partition: PartitionDefinition,
-  settings: Settings)
+    partition: PartitionDefinition,
+    settings: Settings)
   extends ScalaValueReader(partition, settings) {
 
   private val logger: Logger = LoggerFactory.getLogger(classOf[ScalaDorisRowValueReader].getName)
@@ -41,7 +42,7 @@ class ScalaDorisRowValueReader(
       throw new ShouldNeverHappenException
     }
     val row: ScalaDorisRow = new ScalaDorisRow(rowOrder)
-    rowBatch.next.asScala.zipWithIndex.foreach{
+    rowBatch.next.asScala.zipWithIndex.foreach {
       case (s, index) if index < row.values.size => row.values.update(index, s)
       case _ => // nothing
     }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
@@ -18,12 +18,13 @@
 package org.apache.doris.spark.sql
 
 import scala.collection.JavaConversions._
+
+import org.apache.doris.spark.cfg.ConfigurationOptions.DORIS_READ_FIELD
 import org.apache.doris.spark.cfg.Settings
 import org.apache.doris.spark.exception.DorisException
 import org.apache.doris.spark.rest.RestService
 import org.apache.doris.spark.rest.models.{Field, Schema}
 import org.apache.doris.thrift.TScanColumnDesc
-import org.apache.doris.spark.cfg.ConfigurationOptions.DORIS_READ_FIELD
 import org.apache.spark.sql.types._
 import org.slf4j.LoggerFactory
 
@@ -69,9 +70,7 @@ private[spark] object SchemaUtils {
         DataTypes.createStructField(
           f.getName,
           getCatalystType(f.getType, f.getPrecision, f.getScale),
-          true
-        )
-      )
+          true))
     DataTypes.createStructType(fields)
   }
 
@@ -85,34 +84,34 @@ private[spark] object SchemaUtils {
    */
   def getCatalystType(dorisType: String, precision: Int, scale: Int): DataType = {
     dorisType match {
-      case "NULL_TYPE"       => DataTypes.NullType
-      case "BOOLEAN"         => DataTypes.BooleanType
-      case "TINYINT"         => DataTypes.ByteType
-      case "SMALLINT"        => DataTypes.ShortType
-      case "INT"             => DataTypes.IntegerType
-      case "BIGINT"          => DataTypes.LongType
-      case "FLOAT"           => DataTypes.FloatType
-      case "DOUBLE"          => DataTypes.DoubleType
-      case "DATE"            => DataTypes.StringType
-      case "DATEV2"          => DataTypes.StringType
-      case "DATETIME"        => DataTypes.StringType
-      case "DATETIMEV2"      => DataTypes.StringType
-      case "BINARY"          => DataTypes.BinaryType
-      case "DECIMAL"         => DecimalType(precision, scale)
-      case "CHAR"            => DataTypes.StringType
-      case "LARGEINT"        => DataTypes.StringType
-      case "VARCHAR"         => DataTypes.StringType
-      case "JSONB"           => DataTypes.StringType
-      case "DECIMALV2"       => DecimalType(precision, scale)
-      case "DECIMAL32"       => DecimalType(precision, scale)
-      case "DECIMAL64"       => DecimalType(precision, scale)
-      case "DECIMAL128I"     => DecimalType(precision, scale)
-      case "TIME"            => DataTypes.DoubleType
-      case "STRING"          => DataTypes.StringType
-      case "ARRAY"           => DataTypes.StringType
-      case "HLL"             =>
+      case "NULL_TYPE" => DataTypes.NullType
+      case "BOOLEAN" => DataTypes.BooleanType
+      case "TINYINT" => DataTypes.ByteType
+      case "SMALLINT" => DataTypes.ShortType
+      case "INT" => DataTypes.IntegerType
+      case "BIGINT" => DataTypes.LongType
+      case "FLOAT" => DataTypes.FloatType
+      case "DOUBLE" => DataTypes.DoubleType
+      case "DATE" => DataTypes.StringType
+      case "DATEV2" => DataTypes.StringType
+      case "DATETIME" => DataTypes.StringType
+      case "DATETIMEV2" => DataTypes.StringType
+      case "BINARY" => DataTypes.BinaryType
+      case "DECIMAL" => DecimalType(precision, scale)
+      case "CHAR" => DataTypes.StringType
+      case "LARGEINT" => DataTypes.StringType
+      case "VARCHAR" => DataTypes.StringType
+      case "JSONB" => DataTypes.StringType
+      case "DECIMALV2" => DecimalType(precision, scale)
+      case "DECIMAL32" => DecimalType(precision, scale)
+      case "DECIMAL64" => DecimalType(precision, scale)
+      case "DECIMAL128I" => DecimalType(precision, scale)
+      case "TIME" => DataTypes.DoubleType
+      case "STRING" => DataTypes.StringType
+      case "ARRAY" => DataTypes.StringType
+      case "HLL" =>
         throw new DorisException("Unsupported type " + dorisType)
-      case _                 =>
+      case _ =>
         throw new DorisException("Unrecognized Doris type " + dorisType)
     }
   }
@@ -125,7 +124,8 @@ private[spark] object SchemaUtils {
    */
   def convertToSchema(tscanColumnDescs: Seq[TScanColumnDesc]): Schema = {
     val schema = new Schema(tscanColumnDescs.length)
-    tscanColumnDescs.foreach(desc => schema.put(new Field(desc.getName, desc.getType.name, "", 0, 0, "")))
+    tscanColumnDescs.foreach(desc =>
+      schema.put(new Field(desc.getName, desc.getType.name, "", 0, 0, "")))
     schema
   }
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestPartitionDefinition.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestPartitionDefinition.java
@@ -19,52 +19,51 @@ package org.apache.doris.spark.rest;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestPartitionDefinition {
-    private static final String DATABASE_1 = "database1";
-    private static final String TABLE_1 = "table1";
-    private static final String BE_1 = "be1";
-    private static final String QUERY_PLAN_1 = "queryPlan1";
-    private static final long TABLET_ID_1 = 1L;
+  private static final String DATABASE_1 = "database1";
+  private static final String TABLE_1 = "table1";
+  private static final String BE_1 = "be1";
+  private static final String QUERY_PLAN_1 = "queryPlan1";
+  private static final long TABLET_ID_1 = 1L;
 
-    private static final String DATABASE_2 = "database2";
-    private static final String TABLE_2 = "table2";
-    private static final String BE_2 = "be2";
-    private static final String QUERY_PLAN_2 = "queryPlan2";
-    private static final long TABLET_ID_2 = 2L;
+  private static final String DATABASE_2 = "database2";
+  private static final String TABLE_2 = "table2";
+  private static final String BE_2 = "be2";
+  private static final String QUERY_PLAN_2 = "queryPlan2";
+  private static final long TABLET_ID_2 = 2L;
 
-    @Test
-    public void testCompare() throws Exception {
-        Set<Long> tabletSet1 = new HashSet<>();
-        tabletSet1.add(TABLET_ID_1);
-        Set<Long> tabletSet2 = new HashSet<>();
-        tabletSet2.add(TABLET_ID_2);
-        Set<Long> tabletSet3 = new HashSet<>();
-        tabletSet3.add(TABLET_ID_1);
-        tabletSet3.add(TABLET_ID_2);
+  @Test
+  public void testCompare() throws Exception {
+    Set<Long> tabletSet1 = new HashSet<>();
+    tabletSet1.add(TABLET_ID_1);
+    Set<Long> tabletSet2 = new HashSet<>();
+    tabletSet2.add(TABLET_ID_2);
+    Set<Long> tabletSet3 = new HashSet<>();
+    tabletSet3.add(TABLET_ID_1);
+    tabletSet3.add(TABLET_ID_2);
 
-        PartitionDefinition pd1 = new PartitionDefinition(
-                DATABASE_1, TABLE_1, null, BE_1, tabletSet1, QUERY_PLAN_1);
-        PartitionDefinition pd3 = new PartitionDefinition(
-                DATABASE_2, TABLE_1, null, BE_1, tabletSet1, QUERY_PLAN_1);
-        PartitionDefinition pd4 = new PartitionDefinition(
-                DATABASE_1, TABLE_2, null, BE_1, tabletSet1, QUERY_PLAN_1);
-        PartitionDefinition pd5 = new PartitionDefinition(
-                DATABASE_1, TABLE_1, null, BE_2, tabletSet1, QUERY_PLAN_1);
-        PartitionDefinition pd6 = new PartitionDefinition(
-                DATABASE_1, TABLE_1, null, BE_1, tabletSet2, QUERY_PLAN_1);
-        PartitionDefinition pd7 = new PartitionDefinition(
-                DATABASE_1, TABLE_1, null, BE_1, tabletSet3, QUERY_PLAN_1);
-        PartitionDefinition pd8 = new PartitionDefinition(
-                DATABASE_1, TABLE_1, null, BE_1, tabletSet1, QUERY_PLAN_2);
-        Assert.assertTrue(pd1.compareTo(pd3) < 0);
-        Assert.assertTrue(pd1.compareTo(pd4) < 0);
-        Assert.assertTrue(pd1.compareTo(pd5) < 0);
-        Assert.assertTrue(pd1.compareTo(pd6) < 0);
-        Assert.assertTrue(pd1.compareTo(pd7) < 0);
-        Assert.assertTrue(pd1.compareTo(pd8) < 0);
-    }
+    PartitionDefinition pd1 =
+        new PartitionDefinition(DATABASE_1, TABLE_1, null, BE_1, tabletSet1, QUERY_PLAN_1);
+    PartitionDefinition pd3 =
+        new PartitionDefinition(DATABASE_2, TABLE_1, null, BE_1, tabletSet1, QUERY_PLAN_1);
+    PartitionDefinition pd4 =
+        new PartitionDefinition(DATABASE_1, TABLE_2, null, BE_1, tabletSet1, QUERY_PLAN_1);
+    PartitionDefinition pd5 =
+        new PartitionDefinition(DATABASE_1, TABLE_1, null, BE_2, tabletSet1, QUERY_PLAN_1);
+    PartitionDefinition pd6 =
+        new PartitionDefinition(DATABASE_1, TABLE_1, null, BE_1, tabletSet2, QUERY_PLAN_1);
+    PartitionDefinition pd7 =
+        new PartitionDefinition(DATABASE_1, TABLE_1, null, BE_1, tabletSet3, QUERY_PLAN_1);
+    PartitionDefinition pd8 =
+        new PartitionDefinition(DATABASE_1, TABLE_1, null, BE_1, tabletSet1, QUERY_PLAN_2);
+    Assert.assertTrue(pd1.compareTo(pd3) < 0);
+    Assert.assertTrue(pd1.compareTo(pd4) < 0);
+    Assert.assertTrue(pd1.compareTo(pd5) < 0);
+    Assert.assertTrue(pd1.compareTo(pd6) < 0);
+    Assert.assertTrue(pd1.compareTo(pd7) < 0);
+    Assert.assertTrue(pd1.compareTo(pd8) < 0);
+  }
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/TestRestService.java
@@ -32,7 +32,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.doris.spark.cfg.PropertiesSettings;
 import org.apache.doris.spark.cfg.Settings;
 import org.apache.doris.spark.exception.DorisException;
@@ -52,275 +51,292 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TestRestService {
-    private final static Logger logger = LoggerFactory.getLogger(TestRestService.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestRestService.class);
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
-    @Test
-    public void testParseIdentifier() throws Exception {
-        String validIdentifier = "a.b";
-        String[] names = RestService.parseIdentifier(validIdentifier, logger);
-        Assert.assertEquals(2, names.length);
-        Assert.assertEquals("a", names[0]);
-        Assert.assertEquals("b", names[1]);
+  @Test
+  public void testParseIdentifier() throws Exception {
+    String validIdentifier = "a.b";
+    String[] names = RestService.parseIdentifier(validIdentifier, logger);
+    Assert.assertEquals(2, names.length);
+    Assert.assertEquals("a", names[0]);
+    Assert.assertEquals("b", names[1]);
 
-        String invalidIdentifier1 = "a";
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("argument 'table.identifier' is illegal, value is '" + invalidIdentifier1 + "'.");
-        RestService.parseIdentifier(invalidIdentifier1, logger);
+    String invalidIdentifier1 = "a";
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "argument 'table.identifier' is illegal, value is '" + invalidIdentifier1 + "'.");
+    RestService.parseIdentifier(invalidIdentifier1, logger);
 
-        String invalidIdentifier3 = "a.b.c";
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("argument 'table.identifier' is illegal, value is '" + invalidIdentifier3 + "'.");
-        RestService.parseIdentifier(invalidIdentifier3, logger);
+    String invalidIdentifier3 = "a.b.c";
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "argument 'table.identifier' is illegal, value is '" + invalidIdentifier3 + "'.");
+    RestService.parseIdentifier(invalidIdentifier3, logger);
 
-        String emptyIdentifier = "";
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("argument 'table.identifier' is illegal, value is '" + emptyIdentifier + "'.");
-        RestService.parseIdentifier(emptyIdentifier, logger);
+    String emptyIdentifier = "";
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "argument 'table.identifier' is illegal, value is '" + emptyIdentifier + "'.");
+    RestService.parseIdentifier(emptyIdentifier, logger);
 
-        String nullIdentifier = null;
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("argument 'table.identifier' is illegal, value is '" + nullIdentifier + "'.");
-        RestService.parseIdentifier(nullIdentifier, logger);
-    }
+    String nullIdentifier = null;
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(
+        "argument 'table.identifier' is illegal, value is '" + nullIdentifier + "'.");
+    RestService.parseIdentifier(nullIdentifier, logger);
+  }
 
-    @Test
-    public void testChoiceFe() throws Exception {
-        String validFes = "1,2 , 3";
-        String fe = RestService.randomEndpoint(validFes, logger);
-        List<String> feNodes = new ArrayList<>(3);
-        feNodes.add("1");
-        feNodes.add("2");
-        feNodes.add("3");
-        Assert.assertTrue(feNodes.contains(fe));
+  @Test
+  public void testChoiceFe() throws Exception {
+    String validFes = "1,2 , 3";
+    String fe = RestService.randomEndpoint(validFes, logger);
+    List<String> feNodes = new ArrayList<>(3);
+    feNodes.add("1");
+    feNodes.add("2");
+    feNodes.add("3");
+    Assert.assertTrue(feNodes.contains(fe));
 
-        String emptyFes = "";
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("argument 'fenodes' is illegal, value is '" + emptyFes + "'.");
-        RestService.randomEndpoint(emptyFes, logger);
+    String emptyFes = "";
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("argument 'fenodes' is illegal, value is '" + emptyFes + "'.");
+    RestService.randomEndpoint(emptyFes, logger);
 
-        String nullFes = null;
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("argument 'fenodes' is illegal, value is '" + nullFes + "'.");
-        RestService.randomEndpoint(nullFes, logger);
-    }
+    String nullFes = null;
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("argument 'fenodes' is illegal, value is '" + nullFes + "'.");
+    RestService.randomEndpoint(nullFes, logger);
+  }
 
-    @Test
-    public void testGetUriStr() throws Exception {
-        Settings settings = new PropertiesSettings();
-        settings.setProperty(DORIS_TABLE_IDENTIFIER, "a.b");
-        settings.setProperty(DORIS_FENODES, "fe");
+  @Test
+  public void testGetUriStr() throws Exception {
+    Settings settings = new PropertiesSettings();
+    settings.setProperty(DORIS_TABLE_IDENTIFIER, "a.b");
+    settings.setProperty(DORIS_FENODES, "fe");
 
-        String expected = "http://fe/api/a/b/";
-        Assert.assertEquals(expected, RestService.getUriStr(settings, logger));
-    }
+    String expected = "http://fe/api/a/b/";
+    Assert.assertEquals(expected, RestService.getUriStr(settings, logger));
+  }
 
-    @Test
-    public void testFeResponseToSchema() throws Exception {
-        String res = "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\",\"aggregation_type\":\"\"},{\"name\":\"k5\","
-                + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\",\"aggregation_type\":\"\"}],\"status\":200}";
-        Schema expected = new Schema();
-        expected.setStatus(200);
-        Field k1 = new Field("k1", "TINYINT", "", 0, 0, "");
-        Field k5 = new Field("k5", "DECIMALV2", "", 9, 0, "");
-        expected.put(k1);
-        expected.put(k5);
-        Assert.assertEquals(expected, RestService.parseSchema(res, logger));
+  @Test
+  public void testFeResponseToSchema() throws Exception {
+    String res =
+        "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\",\"aggregation_type\":\"\"},{\"name\":\"k5\","
+            + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\",\"aggregation_type\":\"\"}],\"status\":200}";
+    Schema expected = new Schema();
+    expected.setStatus(200);
+    Field k1 = new Field("k1", "TINYINT", "", 0, 0, "");
+    Field k5 = new Field("k5", "DECIMALV2", "", 9, 0, "");
+    expected.put(k1);
+    expected.put(k5);
+    Assert.assertEquals(expected, RestService.parseSchema(res, logger));
 
-        String notJsonRes = "not json";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Doris FE's response is not a json. res:"));
-        RestService.parseSchema(notJsonRes, logger);
+    String notJsonRes = "not json";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Doris FE's response is not a json. res:"));
+    RestService.parseSchema(notJsonRes, logger);
 
-        String notSchemaRes = "{\"property\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},"
-                + "{\"name\":\"k5\",\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\"}],"
-                + "\"status\":200}";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Doris FE's response cannot map to schema. res: "));
-        RestService.parseSchema(notSchemaRes, logger);
+    String notSchemaRes =
+        "{\"property\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},"
+            + "{\"name\":\"k5\",\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\"}],"
+            + "\"status\":200}";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Doris FE's response cannot map to schema. res: "));
+    RestService.parseSchema(notSchemaRes, logger);
 
-        String notOkRes = "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},{\"name\":\"k5\","
-                + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\"}],\"status\":20}";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Doris FE's response is not OK, status is "));
-        RestService.parseSchema(notOkRes, logger);
-    }
+    String notOkRes =
+        "{\"properties\":[{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},{\"name\":\"k5\","
+            + "\"scale\":\"0\",\"comment\":\"\",\"type\":\"DECIMALV2\",\"precision\":\"9\"}],\"status\":20}";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Doris FE's response is not OK, status is "));
+    RestService.parseSchema(notOkRes, logger);
+  }
 
-    @Test
-    public void testFeResponseToQueryPlan() throws Exception {
-        String res = "{\"partitions\":{"
-                + "\"11017\":{\"routings\":[\"be1\",\"be2\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1},"
-                + "\"11019\":{\"routings\":[\"be3\",\"be4\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
-                + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
+  @Test
+  public void testFeResponseToQueryPlan() throws Exception {
+    String res =
+        "{\"partitions\":{"
+            + "\"11017\":{\"routings\":[\"be1\",\"be2\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1},"
+            + "\"11019\":{\"routings\":[\"be3\",\"be4\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
+            + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
 
-        List<String> routings11017 = new ArrayList<>(2);
-        routings11017.add("be1");
-        routings11017.add("be2");
+    List<String> routings11017 = new ArrayList<>(2);
+    routings11017.add("be1");
+    routings11017.add("be2");
 
-        Tablet tablet11017 = new Tablet();
-        tablet11017.setSchemaHash(1);
-        tablet11017.setVersionHash(1);
-        tablet11017.setVersion(3);
-        tablet11017.setRoutings(routings11017);
+    Tablet tablet11017 = new Tablet();
+    tablet11017.setSchemaHash(1);
+    tablet11017.setVersionHash(1);
+    tablet11017.setVersion(3);
+    tablet11017.setRoutings(routings11017);
 
-        List<String> routings11019 = new ArrayList<>(2);
-        routings11019.add("be3");
-        routings11019.add("be4");
+    List<String> routings11019 = new ArrayList<>(2);
+    routings11019.add("be3");
+    routings11019.add("be4");
 
-        Tablet tablet11019 = new Tablet();
-        tablet11019.setSchemaHash(1);
-        tablet11019.setVersionHash(1);
-        tablet11019.setVersion(3);
-        tablet11019.setRoutings(routings11019);
+    Tablet tablet11019 = new Tablet();
+    tablet11019.setSchemaHash(1);
+    tablet11019.setVersionHash(1);
+    tablet11019.setVersion(3);
+    tablet11019.setRoutings(routings11019);
 
-        Map<String, Tablet> partitions = new LinkedHashMap<>();
-        partitions.put("11017", tablet11017);
-        partitions.put("11019", tablet11019);
+    Map<String, Tablet> partitions = new LinkedHashMap<>();
+    partitions.put("11017", tablet11017);
+    partitions.put("11019", tablet11019);
 
-        QueryPlan expected = new QueryPlan();
-        expected.setPartitions(partitions);
-        expected.setStatus(200);
-        expected.setOpaqued_query_plan("query_plan");
+    QueryPlan expected = new QueryPlan();
+    expected.setPartitions(partitions);
+    expected.setStatus(200);
+    expected.setOpaqued_query_plan("query_plan");
 
-        QueryPlan actual = RestService.getQueryPlan(res, logger);
-        Assert.assertEquals(expected, actual);
+    QueryPlan actual = RestService.getQueryPlan(res, logger);
+    Assert.assertEquals(expected, actual);
 
-        String notJsonRes = "not json";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Doris FE's response is not a json. res:"));
-        RestService.parseSchema(notJsonRes, logger);
+    String notJsonRes = "not json";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Doris FE's response is not a json. res:"));
+    RestService.parseSchema(notJsonRes, logger);
 
-        String notQueryPlanRes = "{\"hello\": \"world\"}";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Doris FE's response cannot map to schema. res: "));
-        RestService.parseSchema(notQueryPlanRes, logger);
+    String notQueryPlanRes = "{\"hello\": \"world\"}";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Doris FE's response cannot map to schema. res: "));
+    RestService.parseSchema(notQueryPlanRes, logger);
 
-        String notOkRes = "{\"partitions\":{\"11017\":{\"routings\":[\"be1\",\"be2\"],\"version\":3,"
-                + "\"versionHash\":1,\"schemaHash\":1}},\"opaqued_query_plan\":\"queryPlan\",\"status\":20}";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Doris FE's response is not OK, status is "));
-        RestService.parseSchema(notOkRes, logger);
-    }
+    String notOkRes =
+        "{\"partitions\":{\"11017\":{\"routings\":[\"be1\",\"be2\"],\"version\":3,"
+            + "\"versionHash\":1,\"schemaHash\":1}},\"opaqued_query_plan\":\"queryPlan\",\"status\":20}";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Doris FE's response is not OK, status is "));
+    RestService.parseSchema(notOkRes, logger);
+  }
 
-    @Test
-    public void testSelectTabletBe() throws Exception {
-        String res = "{\"partitions\":{"
-                + "\"11017\":{\"routings\":[\"be1\",\"be2\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1},"
-                + "\"11019\":{\"routings\":[\"be3\",\"be4\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1},"
-                + "\"11021\":{\"routings\":[\"be3\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
-                + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
+  @Test
+  public void testSelectTabletBe() throws Exception {
+    String res =
+        "{\"partitions\":{"
+            + "\"11017\":{\"routings\":[\"be1\",\"be2\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1},"
+            + "\"11019\":{\"routings\":[\"be3\",\"be4\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1},"
+            + "\"11021\":{\"routings\":[\"be3\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
+            + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
 
-        QueryPlan queryPlan = RestService.getQueryPlan(res, logger);
+    QueryPlan queryPlan = RestService.getQueryPlan(res, logger);
 
-        List<Long> be1Tablet = new ArrayList<>();
-        be1Tablet.add(11017L);
-        List<Long> be3Tablet = new ArrayList<>();
-        be3Tablet.add(11019L);
-        be3Tablet.add(11021L);
-        Map<String, List<Long>> expected = new HashMap<>();
-        expected.put("be1", be1Tablet);
-        expected.put("be3", be3Tablet);
+    List<Long> be1Tablet = new ArrayList<>();
+    be1Tablet.add(11017L);
+    List<Long> be3Tablet = new ArrayList<>();
+    be3Tablet.add(11019L);
+    be3Tablet.add(11021L);
+    Map<String, List<Long>> expected = new HashMap<>();
+    expected.put("be1", be1Tablet);
+    expected.put("be3", be3Tablet);
 
-        Assert.assertEquals(expected, RestService.selectBeForTablet(queryPlan, logger));
+    Assert.assertEquals(expected, RestService.selectBeForTablet(queryPlan, logger));
 
-        String noBeRes = "{\"partitions\":{"
-                + "\"11021\":{\"routings\":[],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
-                + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Cannot choice Doris BE for tablet"));
-        RestService.selectBeForTablet(RestService.getQueryPlan(noBeRes, logger), logger);
+    String noBeRes =
+        "{\"partitions\":{"
+            + "\"11021\":{\"routings\":[],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
+            + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Cannot choice Doris BE for tablet"));
+    RestService.selectBeForTablet(RestService.getQueryPlan(noBeRes, logger), logger);
 
-        String notNumberRes = "{\"partitions\":{"
-                + "\"11021xxx\":{\"routings\":[\"be1\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
-                + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
-        thrown.expect(DorisException.class);
-        thrown.expectMessage(startsWith("Parse tablet id "));
-        RestService.selectBeForTablet(RestService.getQueryPlan(noBeRes, logger), logger);
-    }
+    String notNumberRes =
+        "{\"partitions\":{"
+            + "\"11021xxx\":{\"routings\":[\"be1\"],\"version\":3,\"versionHash\":1,\"schemaHash\":1}},"
+            + "\"opaqued_query_plan\":\"query_plan\",\"status\":200}";
+    thrown.expect(DorisException.class);
+    thrown.expectMessage(startsWith("Parse tablet id "));
+    RestService.selectBeForTablet(RestService.getQueryPlan(noBeRes, logger), logger);
+  }
 
-    @Test
-    public void testGetTabletSize() {
-        Settings settings = new PropertiesSettings();
-        Assert.assertEquals(DORIS_TABLET_SIZE_DEFAULT, RestService.tabletCountLimitForOnePartition(settings, logger));
+  @Test
+  public void testGetTabletSize() {
+    Settings settings = new PropertiesSettings();
+    Assert.assertEquals(
+        DORIS_TABLET_SIZE_DEFAULT, RestService.tabletCountLimitForOnePartition(settings, logger));
 
-        settings.setProperty(DORIS_TABLET_SIZE, "xx");
-        Assert.assertEquals(DORIS_TABLET_SIZE_DEFAULT, RestService.tabletCountLimitForOnePartition(settings, logger));
+    settings.setProperty(DORIS_TABLET_SIZE, "xx");
+    Assert.assertEquals(
+        DORIS_TABLET_SIZE_DEFAULT, RestService.tabletCountLimitForOnePartition(settings, logger));
 
-        settings.setProperty(DORIS_TABLET_SIZE, "10");
-        Assert.assertEquals(10, RestService.tabletCountLimitForOnePartition(settings, logger));
+    settings.setProperty(DORIS_TABLET_SIZE, "10");
+    Assert.assertEquals(10, RestService.tabletCountLimitForOnePartition(settings, logger));
 
-        settings.setProperty(DORIS_TABLET_SIZE, "1");
-        Assert.assertEquals(DORIS_TABLET_SIZE_MIN, RestService.tabletCountLimitForOnePartition(settings, logger));
-    }
+    settings.setProperty(DORIS_TABLET_SIZE, "1");
+    Assert.assertEquals(
+        DORIS_TABLET_SIZE_MIN, RestService.tabletCountLimitForOnePartition(settings, logger));
+  }
 
-    @Test
-    public void testTabletsMapToPartition() throws Exception {
-        List<Long> tablets1 = new ArrayList<>();
-        tablets1.add(1L);
-        tablets1.add(2L);
-        List<Long> tablets2 = new ArrayList<>();
-        tablets2.add(3L);
-        tablets2.add(4L);
-        Map<String, List<Long>> beToTablets = new HashMap<>();
-        beToTablets.put("be1", tablets1);
-        beToTablets.put("be2", tablets2);
+  @Test
+  public void testTabletsMapToPartition() throws Exception {
+    List<Long> tablets1 = new ArrayList<>();
+    tablets1.add(1L);
+    tablets1.add(2L);
+    List<Long> tablets2 = new ArrayList<>();
+    tablets2.add(3L);
+    tablets2.add(4L);
+    Map<String, List<Long>> beToTablets = new HashMap<>();
+    beToTablets.put("be1", tablets1);
+    beToTablets.put("be2", tablets2);
 
-        Settings settings = new PropertiesSettings();
-        String opaquedQueryPlan = "query_plan";
-        String cluster = "c";
-        String database = "d";
-        String table = "t";
+    Settings settings = new PropertiesSettings();
+    String opaquedQueryPlan = "query_plan";
+    String cluster = "c";
+    String database = "d";
+    String table = "t";
 
-        Set<Long> be1Tablet = new HashSet<>();
-        be1Tablet.add(1L);
-        be1Tablet.add(2L);
-        PartitionDefinition pd1 = new PartitionDefinition(
-                database, table, settings, "be1", be1Tablet, opaquedQueryPlan);
+    Set<Long> be1Tablet = new HashSet<>();
+    be1Tablet.add(1L);
+    be1Tablet.add(2L);
+    PartitionDefinition pd1 =
+        new PartitionDefinition(database, table, settings, "be1", be1Tablet, opaquedQueryPlan);
 
-        Set<Long> be2Tablet = new HashSet<>();
-        be2Tablet.add(3L);
-        be2Tablet.add(4L);
-        PartitionDefinition pd2 = new PartitionDefinition(
-                database, table, settings, "be2", be2Tablet, opaquedQueryPlan);
+    Set<Long> be2Tablet = new HashSet<>();
+    be2Tablet.add(3L);
+    be2Tablet.add(4L);
+    PartitionDefinition pd2 =
+        new PartitionDefinition(database, table, settings, "be2", be2Tablet, opaquedQueryPlan);
 
-        List<PartitionDefinition> expected = new ArrayList<>();
-        expected.add(pd1);
-        expected.add(pd2);
-        Collections.sort(expected);
+    List<PartitionDefinition> expected = new ArrayList<>();
+    expected.add(pd1);
+    expected.add(pd2);
+    Collections.sort(expected);
 
-        List<PartitionDefinition> actual = RestService.tabletsMapToPartition(
-                settings, beToTablets, opaquedQueryPlan, database, table, logger);
-        Collections.sort(actual);
+    List<PartitionDefinition> actual =
+        RestService.tabletsMapToPartition(
+            settings, beToTablets, opaquedQueryPlan, database, table, logger);
+    Collections.sort(actual);
 
-        Assert.assertEquals(expected, actual);
-    }
+    Assert.assertEquals(expected, actual);
+  }
 
-    @Deprecated
-    @Ignore
-    public void testParseBackend() throws Exception {
-        String response = "{\"href_columns\":[\"BackendId\"],\"parent_url\":\"/rest/v1/system?path=/\"," +
-                "\"column_names\":[\"BackendId\",\"Cluster\",\"IP\",\"HostName\",\"HeartbeatPort\",\"BePort\"," +
-                "\"HttpPort\",\"BrpcPort\",\"LastStartTime\",\"LastHeartbeat\",\"Alive\",\"SystemDecommissioned\"," +
-                "\"ClusterDecommissioned\",\"TabletNum\",\"DataUsedCapacity\",\"AvailCapacity\",\"TotalCapacity\"," +
-                "\"UsedPct\",\"MaxDiskUsedPct\",\"Tag\",\"ErrMsg\",\"Version\",\"Status\"],\"rows\":[{\"HttpPort\":" +
-                "\"8040\",\"Status\":\"{\\\"lastSuccessReportTabletsTime\\\":\\\"N/A\\\",\\\"lastStreamLoadTime\\\":" +
-                "-1}\",\"SystemDecommissioned\":\"false\",\"LastHeartbeat\":\"\\\\N\",\"DataUsedCapacity\":\"0.000 " +
-                "\",\"ErrMsg\":\"\",\"IP\":\"127.0.0.1\",\"UsedPct\":\"0.00 %\",\"__hrefPaths\":[\"/rest/v1/system?" +
-                "path=//backends/10002\"],\"Cluster\":\"default_cluster\",\"Alive\":\"true\",\"MaxDiskUsedPct\":" +
-                "\"0.00 %\",\"BrpcPort\":\"-1\",\"BePort\":\"-1\",\"ClusterDecommissioned\":\"false\"," +
-                "\"AvailCapacity\":\"1.000 B\",\"Version\":\"\",\"BackendId\":\"10002\",\"HeartbeatPort\":\"9050\"," +
-                "\"LastStartTime\":\"\\\\N\",\"TabletNum\":\"0\",\"TotalCapacity\":\"0.000 \",\"Tag\":" +
-                "\"{\\\"location\\\" : \\\"default\\\"}\",\"HostName\":\"localhost\"}]}";
-        List<BackendRow> backendRows = RestService.parseBackend(response, logger);
-        Assert.assertTrue(backendRows != null && !backendRows.isEmpty());
-    }
+  @Deprecated
+  @Ignore
+  public void testParseBackend() throws Exception {
+    String response =
+        "{\"href_columns\":[\"BackendId\"],\"parent_url\":\"/rest/v1/system?path=/\","
+            + "\"column_names\":[\"BackendId\",\"Cluster\",\"IP\",\"HostName\",\"HeartbeatPort\",\"BePort\","
+            + "\"HttpPort\",\"BrpcPort\",\"LastStartTime\",\"LastHeartbeat\",\"Alive\",\"SystemDecommissioned\","
+            + "\"ClusterDecommissioned\",\"TabletNum\",\"DataUsedCapacity\",\"AvailCapacity\",\"TotalCapacity\","
+            + "\"UsedPct\",\"MaxDiskUsedPct\",\"Tag\",\"ErrMsg\",\"Version\",\"Status\"],\"rows\":[{\"HttpPort\":"
+            + "\"8040\",\"Status\":\"{\\\"lastSuccessReportTabletsTime\\\":\\\"N/A\\\",\\\"lastStreamLoadTime\\\":"
+            + "-1}\",\"SystemDecommissioned\":\"false\",\"LastHeartbeat\":\"\\\\N\",\"DataUsedCapacity\":\"0.000 "
+            + "\",\"ErrMsg\":\"\",\"IP\":\"127.0.0.1\",\"UsedPct\":\"0.00 %\",\"__hrefPaths\":[\"/rest/v1/system?"
+            + "path=//backends/10002\"],\"Cluster\":\"default_cluster\",\"Alive\":\"true\",\"MaxDiskUsedPct\":"
+            + "\"0.00 %\",\"BrpcPort\":\"-1\",\"BePort\":\"-1\",\"ClusterDecommissioned\":\"false\","
+            + "\"AvailCapacity\":\"1.000 B\",\"Version\":\"\",\"BackendId\":\"10002\",\"HeartbeatPort\":\"9050\","
+            + "\"LastStartTime\":\"\\\\N\",\"TabletNum\":\"0\",\"TotalCapacity\":\"0.000 \",\"Tag\":"
+            + "\"{\\\"location\\\" : \\\"default\\\"}\",\"HostName\":\"localhost\"}]}";
+    List<BackendRow> backendRows = RestService.parseBackend(response, logger);
+    Assert.assertTrue(backendRows != null && !backendRows.isEmpty());
+  }
 
-    @Test
-    public void testParseBackendV2() throws Exception {
-        String response = "{\"backends\":[{\"ip\":\"192.168.1.1\",\"http_port\":8042,\"is_alive\":true}, {\"ip\":\"192.168.1.2\",\"http_port\":8042,\"is_alive\":true}]}";
-        List<BackendV2.BackendRowV2> backendRows = RestService.parseBackendV2(response, logger);
-        Assert.assertEquals(2, backendRows.size());
-    }
+  @Test
+  public void testParseBackendV2() throws Exception {
+    String response =
+        "{\"backends\":[{\"ip\":\"192.168.1.1\",\"http_port\":8042,\"is_alive\":true}, {\"ip\":\"192.168.1.2\",\"http_port\":8042,\"is_alive\":true}]}";
+    List<BackendV2.BackendRowV2> backendRows = RestService.parseBackendV2(response, logger);
+    Assert.assertEquals(2, backendRows.size());
+  }
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/models/TestSchema.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/rest/models/TestSchema.java
@@ -18,23 +18,22 @@
 package org.apache.doris.spark.rest.models;
 
 import org.junit.Assert;
-import org.junit.Test;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class TestSchema {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
-    @Test
-    public void testPutGet() {
-        Schema ts = new Schema(1);
-        Field f = new Field();
-        ts.put(f);
-        Assert.assertEquals(f, ts.get(0));
+  @Test
+  public void testPutGet() {
+    Schema ts = new Schema(1);
+    Field f = new Field();
+    ts.put(f);
+    Assert.assertEquals(f, ts.get(0));
 
-        thrown.expect(IndexOutOfBoundsException.class);
-        thrown.expectMessage("Index: 1, Fields size：1");
-        ts.get(1);
-    }
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index: 1, Fields size：1");
+    ts.get(1);
+  }
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRouting.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRouting.java
@@ -25,23 +25,21 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-
 public class TestRouting {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
-    @Test
-    public void testRouting() throws Exception {
-        Routing r1 = new Routing("10.11.12.13:1234");
-        Assert.assertEquals("10.11.12.13", r1.getHost());
-        Assert.assertEquals(1234, r1.getPort());
+  @Test
+  public void testRouting() throws Exception {
+    Routing r1 = new Routing("10.11.12.13:1234");
+    Assert.assertEquals("10.11.12.13", r1.getHost());
+    Assert.assertEquals(1234, r1.getPort());
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(startsWith("argument "));
-        new Routing("10.11.12.13:wxyz");
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(startsWith("argument "));
+    new Routing("10.11.12.13:wxyz");
 
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(startsWith("Parse "));
-        new Routing("10.11.12.13");
-    }
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(startsWith("Parse "));
+    new Routing("10.11.12.13");
+  }
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
@@ -19,12 +19,12 @@ package org.apache.doris.spark.serialization;
 
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
+import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
-
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -57,384 +57,389 @@ import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-
 public class TestRowBatch {
-    private final static Logger logger = LoggerFactory.getLogger(TestRowBatch.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestRowBatch.class);
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
-    @Test
-    public void testRowBatch() throws Exception {
-        // schema
-        ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
-        childrenBuilder.add(new Field("k0", FieldType.nullable(new ArrowType.Bool()), null));
-        childrenBuilder.add(new Field("k1", FieldType.nullable(new ArrowType.Int(8, true)), null));
-        childrenBuilder.add(new Field("k2", FieldType.nullable(new ArrowType.Int(16, true)), null));
-        childrenBuilder.add(new Field("k3", FieldType.nullable(new ArrowType.Int(32, true)), null));
-        childrenBuilder.add(new Field("k4", FieldType.nullable(new ArrowType.Int(64, true)), null));
-        childrenBuilder.add(new Field("k9", FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)), null));
-        childrenBuilder.add(new Field("k8", FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null));
-        childrenBuilder.add(new Field("k10", FieldType.nullable(new ArrowType.Utf8()), null));
-        childrenBuilder.add(new Field("k11", FieldType.nullable(new ArrowType.Utf8()), null));
-        childrenBuilder.add(new Field("k5", FieldType.nullable(new ArrowType.Utf8()), null));
-        childrenBuilder.add(new Field("k6", FieldType.nullable(new ArrowType.Utf8()), null));
+  @Test
+  public void testRowBatch() throws Exception {
+    // schema
+    ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
+    childrenBuilder.add(new Field("k0", FieldType.nullable(new ArrowType.Bool()), null));
+    childrenBuilder.add(new Field("k1", FieldType.nullable(new ArrowType.Int(8, true)), null));
+    childrenBuilder.add(new Field("k2", FieldType.nullable(new ArrowType.Int(16, true)), null));
+    childrenBuilder.add(new Field("k3", FieldType.nullable(new ArrowType.Int(32, true)), null));
+    childrenBuilder.add(new Field("k4", FieldType.nullable(new ArrowType.Int(64, true)), null));
+    childrenBuilder.add(
+        new Field(
+            "k9",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
+            null));
+    childrenBuilder.add(
+        new Field(
+            "k8",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            null));
+    childrenBuilder.add(new Field("k10", FieldType.nullable(new ArrowType.Utf8()), null));
+    childrenBuilder.add(new Field("k11", FieldType.nullable(new ArrowType.Utf8()), null));
+    childrenBuilder.add(new Field("k5", FieldType.nullable(new ArrowType.Utf8()), null));
+    childrenBuilder.add(new Field("k6", FieldType.nullable(new ArrowType.Utf8()), null));
 
-        VectorSchemaRoot root = VectorSchemaRoot.create(
-                new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder.build(), null),
-                new RootAllocator(Integer.MAX_VALUE));
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(
-                root,
-                new DictionaryProvider.MapDictionaryProvider(),
-                outputStream);
+    VectorSchemaRoot root =
+        VectorSchemaRoot.create(
+            new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder.build(), null),
+            new RootAllocator(Integer.MAX_VALUE));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ArrowStreamWriter arrowStreamWriter =
+        new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), outputStream);
 
-        arrowStreamWriter.start();
-        root.setRowCount(3);
+    arrowStreamWriter.start();
+    root.setRowCount(3);
 
-        FieldVector vector = root.getVector("k0");
-        BitVector bitVector = (BitVector)vector;
-        bitVector.setInitialCapacity(3);
-        bitVector.allocateNew(3);
-        bitVector.setSafe(0, 1);
-        bitVector.setSafe(1, 0);
-        bitVector.setSafe(2, 1);
-        vector.setValueCount(3);
+    FieldVector vector = root.getVector("k0");
+    BitVector bitVector = (BitVector) vector;
+    bitVector.setInitialCapacity(3);
+    bitVector.allocateNew(3);
+    bitVector.setSafe(0, 1);
+    bitVector.setSafe(1, 0);
+    bitVector.setSafe(2, 1);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k1");
-        TinyIntVector tinyIntVector = (TinyIntVector)vector;
-        tinyIntVector.setInitialCapacity(3);
-        tinyIntVector.allocateNew(3);
-        tinyIntVector.setSafe(0, 1);
-        tinyIntVector.setSafe(1, 2);
-        tinyIntVector.setSafe(2, 3);
-        vector.setValueCount(3);
+    vector = root.getVector("k1");
+    TinyIntVector tinyIntVector = (TinyIntVector) vector;
+    tinyIntVector.setInitialCapacity(3);
+    tinyIntVector.allocateNew(3);
+    tinyIntVector.setSafe(0, 1);
+    tinyIntVector.setSafe(1, 2);
+    tinyIntVector.setSafe(2, 3);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k2");
-        SmallIntVector smallIntVector = (SmallIntVector)vector;
-        smallIntVector.setInitialCapacity(3);
-        smallIntVector.allocateNew(3);
-        smallIntVector.setSafe(0, 1);
-        smallIntVector.setSafe(1, 2);
-        smallIntVector.setSafe(2, 3);
-        vector.setValueCount(3);
+    vector = root.getVector("k2");
+    SmallIntVector smallIntVector = (SmallIntVector) vector;
+    smallIntVector.setInitialCapacity(3);
+    smallIntVector.allocateNew(3);
+    smallIntVector.setSafe(0, 1);
+    smallIntVector.setSafe(1, 2);
+    smallIntVector.setSafe(2, 3);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k3");
-        IntVector intVector = (IntVector)vector;
-        intVector.setInitialCapacity(3);
-        intVector.allocateNew(3);
-        intVector.setSafe(0, 1);
-        intVector.setNull(1);
-        intVector.setSafe(2, 3);
-        vector.setValueCount(3);
+    vector = root.getVector("k3");
+    IntVector intVector = (IntVector) vector;
+    intVector.setInitialCapacity(3);
+    intVector.allocateNew(3);
+    intVector.setSafe(0, 1);
+    intVector.setNull(1);
+    intVector.setSafe(2, 3);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k4");
-        BigIntVector bigIntVector = (BigIntVector)vector;
-        bigIntVector.setInitialCapacity(3);
-        bigIntVector.allocateNew(3);
-        bigIntVector.setSafe(0, 1);
-        bigIntVector.setSafe(1, 2);
-        bigIntVector.setSafe(2, 3);
-        vector.setValueCount(3);
+    vector = root.getVector("k4");
+    BigIntVector bigIntVector = (BigIntVector) vector;
+    bigIntVector.setInitialCapacity(3);
+    bigIntVector.allocateNew(3);
+    bigIntVector.setSafe(0, 1);
+    bigIntVector.setSafe(1, 2);
+    bigIntVector.setSafe(2, 3);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k5");
-        VarCharVector varCharVector = (VarCharVector)vector;
-        varCharVector.setInitialCapacity(3);
-        varCharVector.allocateNew();
-        varCharVector.setIndexDefined(0);
-        varCharVector.setValueLengthSafe(0, 5);
-        varCharVector.setSafe(0, "12.34".getBytes());
-        varCharVector.setIndexDefined(1);
-        varCharVector.setValueLengthSafe(1, 5);
-        varCharVector.setSafe(1, "88.88".getBytes());
-        varCharVector.setIndexDefined(2);
-        varCharVector.setValueLengthSafe(2, 2);
-        varCharVector.setSafe(2, "10".getBytes());
-        vector.setValueCount(3);
+    vector = root.getVector("k5");
+    VarCharVector varCharVector = (VarCharVector) vector;
+    varCharVector.setInitialCapacity(3);
+    varCharVector.allocateNew();
+    varCharVector.setIndexDefined(0);
+    varCharVector.setValueLengthSafe(0, 5);
+    varCharVector.setSafe(0, "12.34".getBytes());
+    varCharVector.setIndexDefined(1);
+    varCharVector.setValueLengthSafe(1, 5);
+    varCharVector.setSafe(1, "88.88".getBytes());
+    varCharVector.setIndexDefined(2);
+    varCharVector.setValueLengthSafe(2, 2);
+    varCharVector.setSafe(2, "10".getBytes());
+    vector.setValueCount(3);
 
-        vector = root.getVector("k6");
-        VarCharVector charVector = (VarCharVector)vector;
-        charVector.setInitialCapacity(3);
-        charVector.allocateNew();
-        charVector.setIndexDefined(0);
-        charVector.setValueLengthSafe(0, 5);
-        charVector.setSafe(0, "char1".getBytes());
-        charVector.setIndexDefined(1);
-        charVector.setValueLengthSafe(1, 5);
-        charVector.setSafe(1, "char2".getBytes());
-        charVector.setIndexDefined(2);
-        charVector.setValueLengthSafe(2, 5);
-        charVector.setSafe(2, "char3".getBytes());
-        vector.setValueCount(3);
+    vector = root.getVector("k6");
+    VarCharVector charVector = (VarCharVector) vector;
+    charVector.setInitialCapacity(3);
+    charVector.allocateNew();
+    charVector.setIndexDefined(0);
+    charVector.setValueLengthSafe(0, 5);
+    charVector.setSafe(0, "char1".getBytes());
+    charVector.setIndexDefined(1);
+    charVector.setValueLengthSafe(1, 5);
+    charVector.setSafe(1, "char2".getBytes());
+    charVector.setIndexDefined(2);
+    charVector.setValueLengthSafe(2, 5);
+    charVector.setSafe(2, "char3".getBytes());
+    vector.setValueCount(3);
 
-        vector = root.getVector("k8");
-        Float8Vector float8Vector = (Float8Vector)vector;
-        float8Vector.setInitialCapacity(3);
-        float8Vector.allocateNew(3);
-        float8Vector.setSafe(0, 1.1);
-        float8Vector.setSafe(1, 2.2);
-        float8Vector.setSafe(2, 3.3);
-        vector.setValueCount(3);
+    vector = root.getVector("k8");
+    Float8Vector float8Vector = (Float8Vector) vector;
+    float8Vector.setInitialCapacity(3);
+    float8Vector.allocateNew(3);
+    float8Vector.setSafe(0, 1.1);
+    float8Vector.setSafe(1, 2.2);
+    float8Vector.setSafe(2, 3.3);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k9");
-        Float4Vector float4Vector = (Float4Vector)vector;
-        float4Vector.setInitialCapacity(3);
-        float4Vector.allocateNew(3);
-        float4Vector.setSafe(0, 1.1f);
-        float4Vector.setSafe(1, 2.2f);
-        float4Vector.setSafe(2, 3.3f);
-        vector.setValueCount(3);
+    vector = root.getVector("k9");
+    Float4Vector float4Vector = (Float4Vector) vector;
+    float4Vector.setInitialCapacity(3);
+    float4Vector.allocateNew(3);
+    float4Vector.setSafe(0, 1.1f);
+    float4Vector.setSafe(1, 2.2f);
+    float4Vector.setSafe(2, 3.3f);
+    vector.setValueCount(3);
 
-        vector = root.getVector("k10");
-        VarCharVector datecharVector = (VarCharVector)vector;
-        datecharVector.setInitialCapacity(3);
-        datecharVector.allocateNew();
-        datecharVector.setIndexDefined(0);
-        datecharVector.setValueLengthSafe(0, 5);
-        datecharVector.setSafe(0, "2008-08-08".getBytes());
-        datecharVector.setIndexDefined(1);
-        datecharVector.setValueLengthSafe(1, 5);
-        datecharVector.setSafe(1, "1900-08-08".getBytes());
-        datecharVector.setIndexDefined(2);
-        datecharVector.setValueLengthSafe(2, 5);
-        datecharVector.setSafe(2, "2100-08-08".getBytes());
-        vector.setValueCount(3);
+    vector = root.getVector("k10");
+    VarCharVector datecharVector = (VarCharVector) vector;
+    datecharVector.setInitialCapacity(3);
+    datecharVector.allocateNew();
+    datecharVector.setIndexDefined(0);
+    datecharVector.setValueLengthSafe(0, 5);
+    datecharVector.setSafe(0, "2008-08-08".getBytes());
+    datecharVector.setIndexDefined(1);
+    datecharVector.setValueLengthSafe(1, 5);
+    datecharVector.setSafe(1, "1900-08-08".getBytes());
+    datecharVector.setIndexDefined(2);
+    datecharVector.setValueLengthSafe(2, 5);
+    datecharVector.setSafe(2, "2100-08-08".getBytes());
+    vector.setValueCount(3);
 
-        vector = root.getVector("k11");
-        VarCharVector timecharVector = (VarCharVector)vector;
-        timecharVector.setInitialCapacity(3);
-        timecharVector.allocateNew();
-        timecharVector.setIndexDefined(0);
-        timecharVector.setValueLengthSafe(0, 5);
-        timecharVector.setSafe(0, "2008-08-08 00:00:00".getBytes());
-        timecharVector.setIndexDefined(1);
-        timecharVector.setValueLengthSafe(1, 5);
-        timecharVector.setSafe(1, "1900-08-08 00:00:00".getBytes());
-        timecharVector.setIndexDefined(2);
-        timecharVector.setValueLengthSafe(2, 5);
-        timecharVector.setSafe(2, "2100-08-08 00:00:00".getBytes());
-        vector.setValueCount(3);
+    vector = root.getVector("k11");
+    VarCharVector timecharVector = (VarCharVector) vector;
+    timecharVector.setInitialCapacity(3);
+    timecharVector.allocateNew();
+    timecharVector.setIndexDefined(0);
+    timecharVector.setValueLengthSafe(0, 5);
+    timecharVector.setSafe(0, "2008-08-08 00:00:00".getBytes());
+    timecharVector.setIndexDefined(1);
+    timecharVector.setValueLengthSafe(1, 5);
+    timecharVector.setSafe(1, "1900-08-08 00:00:00".getBytes());
+    timecharVector.setIndexDefined(2);
+    timecharVector.setValueLengthSafe(2, 5);
+    timecharVector.setSafe(2, "2100-08-08 00:00:00".getBytes());
+    vector.setValueCount(3);
 
-        arrowStreamWriter.writeBatch();
+    arrowStreamWriter.writeBatch();
 
-        arrowStreamWriter.end();
-        arrowStreamWriter.close();
+    arrowStreamWriter.end();
+    arrowStreamWriter.close();
 
-        TStatus status = new TStatus();
-        status.setStatusCode(TStatusCode.OK);
-        TScanBatchResult scanBatchResult = new TScanBatchResult();
-        scanBatchResult.setStatus(status);
-        scanBatchResult.setEos(false);
-        scanBatchResult.setRows(outputStream.toByteArray());
+    TStatus status = new TStatus();
+    status.setStatusCode(TStatusCode.OK);
+    TScanBatchResult scanBatchResult = new TScanBatchResult();
+    scanBatchResult.setStatus(status);
+    scanBatchResult.setEos(false);
+    scanBatchResult.setRows(outputStream.toByteArray());
 
-        String schemaStr = "{\"properties\":[{\"type\":\"BOOLEAN\",\"name\":\"k0\",\"comment\":\"\"},"
-                + "{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},{\"type\":\"SMALLINT\",\"name\":\"k2\","
-                + "\"comment\":\"\"},{\"type\":\"INT\",\"name\":\"k3\",\"comment\":\"\"},{\"type\":\"BIGINT\","
-                + "\"name\":\"k4\",\"comment\":\"\"},{\"type\":\"FLOAT\",\"name\":\"k9\",\"comment\":\"\"},"
-                + "{\"type\":\"DOUBLE\",\"name\":\"k8\",\"comment\":\"\"},{\"type\":\"DATE\",\"name\":\"k10\","
-                + "\"comment\":\"\"},{\"type\":\"DATETIME\",\"name\":\"k11\",\"comment\":\"\"},"
-                + "{\"name\":\"k5\",\"scale\":\"0\",\"comment\":\"\","
-                + "\"type\":\"DECIMAL\",\"precision\":\"9\",\"aggregation_type\":\"\"},{\"type\":\"CHAR\",\"name\":\"k6\",\"comment\":\"\",\"aggregation_type\":\"REPLACE_IF_NOT_NULL\"}],"
-                + "\"status\":200}";
+    String schemaStr =
+        "{\"properties\":[{\"type\":\"BOOLEAN\",\"name\":\"k0\",\"comment\":\"\"},"
+            + "{\"type\":\"TINYINT\",\"name\":\"k1\",\"comment\":\"\"},{\"type\":\"SMALLINT\",\"name\":\"k2\","
+            + "\"comment\":\"\"},{\"type\":\"INT\",\"name\":\"k3\",\"comment\":\"\"},{\"type\":\"BIGINT\","
+            + "\"name\":\"k4\",\"comment\":\"\"},{\"type\":\"FLOAT\",\"name\":\"k9\",\"comment\":\"\"},"
+            + "{\"type\":\"DOUBLE\",\"name\":\"k8\",\"comment\":\"\"},{\"type\":\"DATE\",\"name\":\"k10\","
+            + "\"comment\":\"\"},{\"type\":\"DATETIME\",\"name\":\"k11\",\"comment\":\"\"},"
+            + "{\"name\":\"k5\",\"scale\":\"0\",\"comment\":\"\","
+            + "\"type\":\"DECIMAL\",\"precision\":\"9\",\"aggregation_type\":\"\"},{\"type\":\"CHAR\",\"name\":\"k6\",\"comment\":\"\",\"aggregation_type\":\"REPLACE_IF_NOT_NULL\"}],"
+            + "\"status\":200}";
 
-        Schema schema = RestService.parseSchema(schemaStr, logger);
+    Schema schema = RestService.parseSchema(schemaStr, logger);
 
-        RowBatch rowBatch = new RowBatch(scanBatchResult, schema);
+    RowBatch rowBatch = new RowBatch(scanBatchResult, schema);
 
-        List<Object> expectedRow1 = Arrays.asList(
-                Boolean.TRUE,
-                (byte) 1,
-                (short) 1,
-                1,
-                1L,
-                (float) 1.1,
-                (double) 1.1,
-                "2008-08-08",
-                "2008-08-08 00:00:00",
-                Decimal.apply(1234L, 4, 2),
-                "char1"
-        );
+    List<Object> expectedRow1 =
+        Arrays.asList(
+            Boolean.TRUE,
+            (byte) 1,
+            (short) 1,
+            1,
+            1L,
+            (float) 1.1,
+            (double) 1.1,
+            "2008-08-08",
+            "2008-08-08 00:00:00",
+            Decimal.apply(1234L, 4, 2),
+            "char1");
 
-        List<Object> expectedRow2 = Arrays.asList(
-                Boolean.FALSE,
-                (byte) 2,
-                (short) 2,
-                null,
-                2L,
-                (float) 2.2,
-                (double) 2.2,
-                "1900-08-08",
-                "1900-08-08 00:00:00",
-                Decimal.apply(8888L, 4, 2),
-                "char2"
-        );
+    List<Object> expectedRow2 =
+        Arrays.asList(
+            Boolean.FALSE,
+            (byte) 2,
+            (short) 2,
+            null,
+            2L,
+            (float) 2.2,
+            (double) 2.2,
+            "1900-08-08",
+            "1900-08-08 00:00:00",
+            Decimal.apply(8888L, 4, 2),
+            "char2");
 
-        List<Object> expectedRow3 = Arrays.asList(
-                Boolean.TRUE,
-                (byte) 3,
-                (short) 3,
-                3,
-                3L,
-                (float) 3.3,
-                (double) 3.3,
-                "2100-08-08",
-                "2100-08-08 00:00:00",
-                Decimal.apply(10L, 2, 0),
-                "char3"
-        );
+    List<Object> expectedRow3 =
+        Arrays.asList(
+            Boolean.TRUE,
+            (byte) 3,
+            (short) 3,
+            3,
+            3L,
+            (float) 3.3,
+            (double) 3.3,
+            "2100-08-08",
+            "2100-08-08 00:00:00",
+            Decimal.apply(10L, 2, 0),
+            "char3");
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow1 = rowBatch.next();
-        Assert.assertEquals(expectedRow1, actualRow1);
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow1 = rowBatch.next();
+    Assert.assertEquals(expectedRow1, actualRow1);
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow2 = rowBatch.next();
-        Assert.assertEquals(expectedRow2, actualRow2);
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow2 = rowBatch.next();
+    Assert.assertEquals(expectedRow2, actualRow2);
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow3 = rowBatch.next();
-        Assert.assertEquals(expectedRow3, actualRow3);
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow3 = rowBatch.next();
+    Assert.assertEquals(expectedRow3, actualRow3);
 
-        Assert.assertFalse(rowBatch.hasNext());
-        thrown.expect(NoSuchElementException.class);
-        thrown.expectMessage(startsWith("Get row offset:"));
-        rowBatch.next();
-    }
+    Assert.assertFalse(rowBatch.hasNext());
+    thrown.expect(NoSuchElementException.class);
+    thrown.expectMessage(startsWith("Get row offset:"));
+    rowBatch.next();
+  }
 
-    @Test
-    public void testBinary() throws Exception {
-        byte[] binaryRow0 = {'a', 'b', 'c'};
-        byte[] binaryRow1 = {'d', 'e', 'f'};
-        byte[] binaryRow2 = {'g', 'h', 'i'};
+  @Test
+  public void testBinary() throws Exception {
+    byte[] binaryRow0 = {'a', 'b', 'c'};
+    byte[] binaryRow1 = {'d', 'e', 'f'};
+    byte[] binaryRow2 = {'g', 'h', 'i'};
 
-        ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
-        childrenBuilder.add(new Field("k7", FieldType.nullable(new ArrowType.Binary()), null));
+    ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
+    childrenBuilder.add(new Field("k7", FieldType.nullable(new ArrowType.Binary()), null));
 
-        VectorSchemaRoot root = VectorSchemaRoot.create(
-                new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder.build(), null),
-                new RootAllocator(Integer.MAX_VALUE));
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(
-                root,
-                new DictionaryProvider.MapDictionaryProvider(),
-                outputStream);
+    VectorSchemaRoot root =
+        VectorSchemaRoot.create(
+            new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder.build(), null),
+            new RootAllocator(Integer.MAX_VALUE));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ArrowStreamWriter arrowStreamWriter =
+        new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), outputStream);
 
-        arrowStreamWriter.start();
-        root.setRowCount(3);
+    arrowStreamWriter.start();
+    root.setRowCount(3);
 
-        FieldVector vector = root.getVector("k7");
-        VarBinaryVector varBinaryVector = (VarBinaryVector) vector;
-        varBinaryVector.setInitialCapacity(3);
-        varBinaryVector.allocateNew();
-        varBinaryVector.setIndexDefined(0);
-        varBinaryVector.setValueLengthSafe(0, 3);
-        varBinaryVector.setSafe(0, binaryRow0);
-        varBinaryVector.setIndexDefined(1);
-        varBinaryVector.setValueLengthSafe(1, 3);
-        varBinaryVector.setSafe(1, binaryRow1);
-        varBinaryVector.setIndexDefined(2);
-        varBinaryVector.setValueLengthSafe(2, 3);
-        varBinaryVector.setSafe(2, binaryRow2);
-        vector.setValueCount(3);
+    FieldVector vector = root.getVector("k7");
+    VarBinaryVector varBinaryVector = (VarBinaryVector) vector;
+    varBinaryVector.setInitialCapacity(3);
+    varBinaryVector.allocateNew();
+    varBinaryVector.setIndexDefined(0);
+    varBinaryVector.setValueLengthSafe(0, 3);
+    varBinaryVector.setSafe(0, binaryRow0);
+    varBinaryVector.setIndexDefined(1);
+    varBinaryVector.setValueLengthSafe(1, 3);
+    varBinaryVector.setSafe(1, binaryRow1);
+    varBinaryVector.setIndexDefined(2);
+    varBinaryVector.setValueLengthSafe(2, 3);
+    varBinaryVector.setSafe(2, binaryRow2);
+    vector.setValueCount(3);
 
-        arrowStreamWriter.writeBatch();
+    arrowStreamWriter.writeBatch();
 
-        arrowStreamWriter.end();
-        arrowStreamWriter.close();
+    arrowStreamWriter.end();
+    arrowStreamWriter.close();
 
-        TStatus status = new TStatus();
-        status.setStatusCode(TStatusCode.OK);
-        TScanBatchResult scanBatchResult = new TScanBatchResult();
-        scanBatchResult.setStatus(status);
-        scanBatchResult.setEos(false);
-        scanBatchResult.setRows(outputStream.toByteArray());
+    TStatus status = new TStatus();
+    status.setStatusCode(TStatusCode.OK);
+    TScanBatchResult scanBatchResult = new TScanBatchResult();
+    scanBatchResult.setStatus(status);
+    scanBatchResult.setEos(false);
+    scanBatchResult.setRows(outputStream.toByteArray());
 
-        String schemaStr = "{\"properties\":[{\"type\":\"BINARY\",\"name\":\"k7\",\"comment\":\"\"}], \"status\":200}";
+    String schemaStr =
+        "{\"properties\":[{\"type\":\"BINARY\",\"name\":\"k7\",\"comment\":\"\"}], \"status\":200}";
 
-        Schema schema = RestService.parseSchema(schemaStr, logger);
+    Schema schema = RestService.parseSchema(schemaStr, logger);
 
-        RowBatch rowBatch = new RowBatch(scanBatchResult, schema);
+    RowBatch rowBatch = new RowBatch(scanBatchResult, schema);
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow0 = rowBatch.next();
-        Assert.assertArrayEquals(binaryRow0, (byte[])actualRow0.get(0));
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow0 = rowBatch.next();
+    Assert.assertArrayEquals(binaryRow0, (byte[]) actualRow0.get(0));
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow1 = rowBatch.next();
-        Assert.assertArrayEquals(binaryRow1, (byte[])actualRow1.get(0));
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow1 = rowBatch.next();
+    Assert.assertArrayEquals(binaryRow1, (byte[]) actualRow1.get(0));
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow2 = rowBatch.next();
-        Assert.assertArrayEquals(binaryRow2, (byte[])actualRow2.get(0));
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow2 = rowBatch.next();
+    Assert.assertArrayEquals(binaryRow2, (byte[]) actualRow2.get(0));
 
-        Assert.assertFalse(rowBatch.hasNext());
-        thrown.expect(NoSuchElementException.class);
-        thrown.expectMessage(startsWith("Get row offset:"));
-        rowBatch.next();
-    }
+    Assert.assertFalse(rowBatch.hasNext());
+    thrown.expect(NoSuchElementException.class);
+    thrown.expectMessage(startsWith("Get row offset:"));
+    rowBatch.next();
+  }
 
-    @Test
-    public void testDecimalV2() throws Exception {
-        ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
-        childrenBuilder.add(new Field("k7", FieldType.nullable(new ArrowType.Decimal(27, 9)), null));
+  @Test
+  public void testDecimalV2() throws Exception {
+    ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
+    childrenBuilder.add(new Field("k7", FieldType.nullable(new ArrowType.Decimal(27, 9)), null));
 
-        VectorSchemaRoot root = VectorSchemaRoot.create(
-                new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder.build(), null),
-                new RootAllocator(Integer.MAX_VALUE));
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(
-                root,
-                new DictionaryProvider.MapDictionaryProvider(),
-                outputStream);
+    VectorSchemaRoot root =
+        VectorSchemaRoot.create(
+            new org.apache.arrow.vector.types.pojo.Schema(childrenBuilder.build(), null),
+            new RootAllocator(Integer.MAX_VALUE));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ArrowStreamWriter arrowStreamWriter =
+        new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), outputStream);
 
-        arrowStreamWriter.start();
-        root.setRowCount(3);
+    arrowStreamWriter.start();
+    root.setRowCount(3);
 
-        FieldVector vector = root.getVector("k7");
-        DecimalVector decimalVector = (DecimalVector) vector;
-        decimalVector.setInitialCapacity(3);
-        decimalVector.allocateNew(3);
-        decimalVector.setSafe(0, new BigDecimal("12.340000000"));
-        decimalVector.setSafe(1, new BigDecimal("88.880000000"));
-        decimalVector.setSafe(2, new BigDecimal("10.000000000"));
-        vector.setValueCount(3);
+    FieldVector vector = root.getVector("k7");
+    DecimalVector decimalVector = (DecimalVector) vector;
+    decimalVector.setInitialCapacity(3);
+    decimalVector.allocateNew(3);
+    decimalVector.setSafe(0, new BigDecimal("12.340000000"));
+    decimalVector.setSafe(1, new BigDecimal("88.880000000"));
+    decimalVector.setSafe(2, new BigDecimal("10.000000000"));
+    vector.setValueCount(3);
 
-        arrowStreamWriter.writeBatch();
+    arrowStreamWriter.writeBatch();
 
-        arrowStreamWriter.end();
-        arrowStreamWriter.close();
+    arrowStreamWriter.end();
+    arrowStreamWriter.close();
 
-        TStatus status = new TStatus();
-        status.setStatusCode(TStatusCode.OK);
-        TScanBatchResult scanBatchResult = new TScanBatchResult();
-        scanBatchResult.setStatus(status);
-        scanBatchResult.setEos(false);
-        scanBatchResult.setRows(outputStream.toByteArray());
+    TStatus status = new TStatus();
+    status.setStatusCode(TStatusCode.OK);
+    TScanBatchResult scanBatchResult = new TScanBatchResult();
+    scanBatchResult.setStatus(status);
+    scanBatchResult.setEos(false);
+    scanBatchResult.setRows(outputStream.toByteArray());
 
-        String schemaStr = "{\"properties\":[{\"type\":\"DECIMALV2\",\"scale\": 0,"
-                + "\"precision\": 9, \"name\":\"k7\",\"comment\":\"\"}], "
-                + "\"status\":200}";
+    String schemaStr =
+        "{\"properties\":[{\"type\":\"DECIMALV2\",\"scale\": 0,"
+            + "\"precision\": 9, \"name\":\"k7\",\"comment\":\"\"}], "
+            + "\"status\":200}";
 
-        Schema schema = RestService.parseSchema(schemaStr, logger);
+    Schema schema = RestService.parseSchema(schemaStr, logger);
 
-        RowBatch rowBatch = new RowBatch(scanBatchResult, schema);
+    RowBatch rowBatch = new RowBatch(scanBatchResult, schema);
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow0 = rowBatch.next();
-        Assert.assertEquals(Decimal.apply(12340000000L, 11, 9), (Decimal)actualRow0.get(0));
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow0 = rowBatch.next();
+    Assert.assertEquals(Decimal.apply(12340000000L, 11, 9), (Decimal) actualRow0.get(0));
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow1 = rowBatch.next();
-        Assert.assertEquals(Decimal.apply(88880000000L, 11, 9), (Decimal)actualRow1.get(0));
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow1 = rowBatch.next();
+    Assert.assertEquals(Decimal.apply(88880000000L, 11, 9), (Decimal) actualRow1.get(0));
 
-        Assert.assertTrue(rowBatch.hasNext());
-        List<Object> actualRow2 = rowBatch.next();
-        Assert.assertEquals(Decimal.apply(10000000000L, 11, 9), (Decimal)actualRow2.get(0));
+    Assert.assertTrue(rowBatch.hasNext());
+    List<Object> actualRow2 = rowBatch.next();
+    Assert.assertEquals(Decimal.apply(10000000000L, 11, 9), (Decimal) actualRow2.get(0));
 
-        Assert.assertFalse(rowBatch.hasNext());
-        thrown.expect(NoSuchElementException.class);
-        thrown.expectMessage(startsWith("Get row offset:"));
-        rowBatch.next();
-    }
+    Assert.assertFalse(rowBatch.hasNext());
+    thrown.expect(NoSuchElementException.class);
+    thrown.expectMessage(startsWith("Get row offset:"));
+    rowBatch.next();
+  }
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/sql/ExpectedExceptionTest.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/sql/ExpectedExceptionTest.java
@@ -21,6 +21,5 @@ import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
 public class ExpectedExceptionTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/util/TestListUtils.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/util/TestListUtils.java
@@ -17,26 +17,25 @@
 
 package org.apache.doris.spark.util;
 
-import org.junit.Assert;
-import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestListUtils {
 
-    @Test
-    public void testGetSerializedList() throws Exception {
-        int size = 15000;
-        List<Map<Object, Object>> batch = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            Map<Object, Object> entity = new HashMap<>();
-            batch.add(entity);
-        }
-        Assert.assertEquals(ListUtils.getSerializedList(batch).size(), 1);
-
-        Assert.assertEquals(ListUtils.getSerializedList(new ArrayList<>()).size(), 1);
-
+  @Test
+  public void testGetSerializedList() throws Exception {
+    int size = 15000;
+    List<Map<Object, Object>> batch = new ArrayList<>();
+    for (int i = 0; i < size; i++) {
+      Map<Object, Object> entity = new HashMap<>();
+      batch.add(entity);
     }
+    Assert.assertEquals(ListUtils.getSerializedList(batch).size(), 1);
+
+    Assert.assertEquals(ListUtils.getSerializedList(new ArrayList<>()).size(), 1);
+  }
 }

--- a/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestConnectorWriteDoris.scala
+++ b/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestConnectorWriteDoris.scala
@@ -39,8 +39,7 @@ class TestConnectorWriteDoris {
     val df = spark.createDataFrame(Seq(
       ("1", 100, "待付款"),
       ("2", 200, "待发货"),
-      ("3", 300, "已收货")
-    )).toDF("order_id", "order_amount", "order_status")
+      ("3", 300, "已收货"))).toDF("order_id", "order_amount", "order_status")
     df.write
       .format("doris")
       .option("doris.fenodes", dorisFeNodes)
@@ -52,7 +51,6 @@ class TestConnectorWriteDoris {
       .save()
     spark.stop()
   }
-
 
   @Test
   def csvDataWriteTest(): Unit = {
@@ -66,15 +64,15 @@ class TestConnectorWriteDoris {
     df.createTempView("tmp_tb")
     val doris = spark.sql(
       s"""
-        |CREATE TEMPORARY VIEW test_lh
-        |USING doris
-        |OPTIONS(
-        | "table.identifier"="test.test_lh",
-        | "fenodes"="${dorisFeNodes}",
-        | "user"="${dorisUser}",
-        | "password"="${dorisPwd}"
-        |);
-        |""".stripMargin)
+         |CREATE TEMPORARY VIEW test_lh
+         |USING doris
+         |OPTIONS(
+         | "table.identifier"="test.test_lh",
+         | "fenodes"="${dorisFeNodes}",
+         | "user"="${dorisUser}",
+         | "password"="${dorisPwd}"
+         |);
+         |""".stripMargin)
     spark.sql(
       """
         |insert into test_lh select  name,gender,age from tmp_tb ;

--- a/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSchemaUtils.scala
+++ b/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSchemaUtils.scala
@@ -17,14 +17,14 @@
 
 package org.apache.doris.spark.sql
 
+import scala.collection.JavaConverters._
+
 import org.apache.doris.spark.exception.DorisException
 import org.apache.doris.spark.rest.models.{Field, Schema}
 import org.apache.doris.thrift.{TPrimitiveType, TScanColumnDesc}
 import org.apache.spark.sql.types._
 import org.hamcrest.core.StringStartsWith.startsWith
 import org.junit.{Assert, Ignore, Test}
-
-import scala.collection.JavaConverters._
 
 @Ignore
 class TestSchemaUtils extends ExpectedExceptionTest {

--- a/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSparkConnector.scala
+++ b/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSparkConnector.scala
@@ -17,8 +17,8 @@
 
 package org.apache.doris.spark.sql
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
 import org.junit.Ignore
 import org.junit.Test
 
@@ -44,9 +44,7 @@ class TestSparkConnector {
       cfg = Some(Map(
         "doris.fenodes" -> dorisFeNodes,
         "doris.request.auth.user" -> dorisUser,
-        "doris.request.auth.password" -> dorisPwd
-      ))
-    )
+        "doris.request.auth.password" -> dorisPwd)))
     dorisSparkRDD.map(println(_)).count()
     sc.stop()
   }
@@ -57,18 +55,17 @@ class TestSparkConnector {
     val df = session.createDataFrame(Seq(
       ("zhangsan", "m"),
       ("lisi", "f"),
-      ("wangwu", "m")
-    )).toDF("name","gender")
+      ("wangwu", "m"))).toDF("name", "gender")
     df.write
       .format("doris")
       .option("doris.fenodes", dorisFeNodes)
       .option("doris.table.identifier", dorisTable)
       .option("user", dorisUser)
       .option("password", dorisPwd)
-      //specify your field
+      // specify your field
       .option("doris.write.fields", "name,gender")
-      .option("sink.batch.size",2)
-      .option("sink.max-retries",2)
+      .option("sink.batch.size", 2)
+      .option("sink.max-retries", 2)
       .save()
     session.stop()
   }
@@ -87,7 +84,6 @@ class TestSparkConnector {
     dorisSparkDF.show()
     session.stop()
   }
-
 
   @Test
   def structuredStreamingWriteTest(): Unit = {
@@ -110,10 +106,9 @@ class TestSparkConnector {
       .option("doris.fenodes", dorisFeNodes)
       .option("user", dorisUser)
       .option("password", dorisPwd)
-      .option("sink.batch.size",2)
-      .option("sink.max-retries",2)
+      .option("sink.batch.size", 2)
+      .option("sink.max-retries", 2)
       .start().awaitTermination()
     spark.stop()
   }
 }
-

--- a/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestUtils.scala
+++ b/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestUtils.scala
@@ -49,20 +49,38 @@ class TestUtils extends ExpectedExceptionTest {
     val validOrFilter = Or(equalFilter, greaterThanFilter)
     val invalidOrFilter = Or(equalFilter, notSupportFilter)
 
-    Assert.assertEquals("`left` = 5", Utils.compileFilter(equalFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("`left` > 5", Utils.compileFilter(greaterThanFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("`left` >= 5", Utils.compileFilter(greaterThanOrEqualFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("`left` < 5", Utils.compileFilter(lessThanFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("`left` <= 5", Utils.compileFilter(lessThanOrEqualFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("`left` in (1, 2, 3, 4)", Utils.compileFilter(validInFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` = 5",
+      Utils.compileFilter(equalFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` > 5",
+      Utils.compileFilter(greaterThanFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` >= 5",
+      Utils.compileFilter(greaterThanOrEqualFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` < 5",
+      Utils.compileFilter(lessThanFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` <= 5",
+      Utils.compileFilter(lessThanOrEqualFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` in (1, 2, 3, 4)",
+      Utils.compileFilter(validInFilter, dialect, inValueLengthLimit).get)
     Assert.assertTrue(Utils.compileFilter(emptyInFilter, dialect, inValueLengthLimit).isEmpty)
     Assert.assertTrue(Utils.compileFilter(invalidInFilter, dialect, inValueLengthLimit).isEmpty)
-    Assert.assertEquals("`left` is null", Utils.compileFilter(isNullFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("`left` is not null", Utils.compileFilter(isNotNullFilter, dialect, inValueLengthLimit).get)
-    Assert.assertEquals("(`left` = 5) and (`left` > 5)",
+    Assert.assertEquals(
+      "`left` is null",
+      Utils.compileFilter(isNullFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "`left` is not null",
+      Utils.compileFilter(isNotNullFilter, dialect, inValueLengthLimit).get)
+    Assert.assertEquals(
+      "(`left` = 5) and (`left` > 5)",
       Utils.compileFilter(validAndFilter, dialect, inValueLengthLimit).get)
     Assert.assertTrue(Utils.compileFilter(invalidAndFilter, dialect, inValueLengthLimit).isEmpty)
-    Assert.assertEquals("(`left` = 5) or (`left` > 5)",
+    Assert.assertEquals(
+      "(`left` = 5) or (`left` > 5)",
       Utils.compileFilter(validOrFilter, dialect, inValueLengthLimit).get)
     Assert.assertTrue(Utils.compileFilter(invalidOrFilter, dialect, inValueLengthLimit).isEmpty)
   }
@@ -73,48 +91,45 @@ class TestUtils extends ExpectedExceptionTest {
       ConfigurationOptions.DORIS_TABLE_IDENTIFIER -> "a.b",
       "test_underline" -> "x_y",
       "user" -> "user",
-      "password" -> "password"
-    )
+      "password" -> "password")
     val result1 = Utils.params(parameters1, logger)
     Assert.assertEquals("a.b", result1(ConfigurationOptions.DORIS_TABLE_IDENTIFIER))
     Assert.assertEquals("x_y", result1("doris.test.underline"))
     Assert.assertEquals("user", result1("doris.request.auth.user"))
     Assert.assertEquals("password", result1("doris.request.auth.password"))
 
-
     val parameters2 = Map(
-      ConfigurationOptions.TABLE_IDENTIFIER -> "a.b"
-    )
+      ConfigurationOptions.TABLE_IDENTIFIER -> "a.b")
     val result2 = Utils.params(parameters2, logger)
     Assert.assertEquals("a.b", result2(ConfigurationOptions.DORIS_TABLE_IDENTIFIER))
 
     val parameters3 = Map(
-      ConfigurationOptions.DORIS_PASSWORD -> "a.b"
-    )
+      ConfigurationOptions.DORIS_PASSWORD -> "a.b")
     thrown.expect(classOf[DorisException])
-    thrown.expectMessage(startsWith(s"${ConfigurationOptions.DORIS_PASSWORD} cannot use in Doris Datasource,"))
+    thrown.expectMessage(
+      startsWith(s"${ConfigurationOptions.DORIS_PASSWORD} cannot use in Doris Datasource,"))
     Utils.params(parameters3, logger)
 
     val parameters4 = Map(
-      ConfigurationOptions.DORIS_USER -> "a.b"
-    )
+      ConfigurationOptions.DORIS_USER -> "a.b")
     thrown.expect(classOf[DorisException])
-    thrown.expectMessage(startsWith(s"${ConfigurationOptions.DORIS_USER} cannot use in Doris Datasource,"))
+    thrown.expectMessage(
+      startsWith(s"${ConfigurationOptions.DORIS_USER} cannot use in Doris Datasource,"))
     Utils.params(parameters4, logger)
 
     val parameters5 = Map(
-      ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD -> "a.b"
-    )
+      ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD -> "a.b")
     thrown.expect(classOf[DorisException])
     thrown.expectMessage(
-      startsWith(s"${ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD} cannot use in Doris Datasource,"))
+      startsWith(
+        s"${ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD} cannot use in Doris Datasource,"))
     Utils.params(parameters5, logger)
 
     val parameters6 = Map(
-      ConfigurationOptions.DORIS_REQUEST_AUTH_USER -> "a.b"
-    )
+      ConfigurationOptions.DORIS_REQUEST_AUTH_USER -> "a.b")
     thrown.expect(classOf[DorisException])
-    thrown.expectMessage(startsWith(s"${ConfigurationOptions.DORIS_REQUEST_AUTH_USER} cannot use in Doris Datasource,"))
+    thrown.expectMessage(startsWith(
+      s"${ConfigurationOptions.DORIS_REQUEST_AUTH_USER} cannot use in Doris Datasource,"))
     Utils.params(parameters6, logger)
   }
 }


### PR DESCRIPTION
# Proposed changes

A code style linter is the key to making all the git history traceable and readable.

- introduce the spotless maven plugin for linting Scala and Java code
- spotless maven plugin 2.30.0 is the last available version for Java 8
- use ScalaFmt for Sala code linting, the style config file `.scalafmt.conf` also help lint on local IDE
- use Google Java Format for Java linting, 1.7  is the last available version for Java 8
- auto checked in CI builds with maven, and easy to apply fixes by running `mvn spotless:apply`

The scala style rules are mainly referred to Apache Kyuubi's practice here (https://github.com/apache/kyuubi/blob/master/.scalafmt.conf).

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
