### PR TITLE
[Infra] Upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/approve-label.yml
+++ b/.github/workflows/approve-label.yml
@@ -37,7 +37,7 @@ jobs:
       isApprovedByAnyone: ${{ steps.label-when-approved-by-anyone.outputs.isApproved }}
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
 
     - name: Setup java
       uses: actions/setup-java@v3

--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check License
         uses: apache/skywalking-eyes@v0.2.0
         env:


### PR DESCRIPTION
# Proposed changes

- Bump checkout action in CI builds from v2 to v3 (https://github.com/actions/checkout)

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
