### PR TITLE
improve the sink format handle logic by factory pattern 

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/CachedDorisStreamLoadClient.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/CachedDorisStreamLoadClient.java
@@ -24,6 +24,7 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import org.apache.doris.spark.cfg.SparkSettings;
 import org.apache.doris.spark.exception.DorisException;
+import org.apache.doris.spark.exception.StreamLoadException;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -39,17 +40,14 @@ public class CachedDorisStreamLoadClient {
     static {
         dorisStreamLoadLoadingCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTimeout, TimeUnit.SECONDS)
-                .removalListener(new RemovalListener<Object, Object>() {
-                    @Override
-                    public void onRemoval(RemovalNotification<Object, Object> removalNotification) {
-                        //do nothing
-                    }
+                .removalListener(removalNotification -> {
+                    //do nothing
                 })
                 .build(
                         new CacheLoader<SparkSettings, DorisStreamLoad>() {
                             @Override
-                            public DorisStreamLoad load(SparkSettings sparkSettings) throws IOException, DorisException {
-                                DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(sparkSettings);
+                            public DorisStreamLoad load(SparkSettings sparkSettings) throws StreamLoadException {
+                                DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(sparkSettings,null);
                                 return dorisStreamLoad;
                             }
                         }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -122,6 +122,8 @@ public class DorisStreamLoad implements Serializable {
         }
         if (dataFormat.getType().equalsIgnoreCase(FormatEnum.json.name())) {
             httpPut.setHeader("strip_outer_array", "true");
+            //to solve the error : The size of this batch exceed the max size [104857600]  of json type data. Split the file, or use 'read_json_by_line'
+            httpPut.setHeader("read_json_by_line","true");
         }
         return httpPut;
     }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -122,8 +122,6 @@ public class DorisStreamLoad implements Serializable {
         }
         if (dataFormat.getType().equalsIgnoreCase(FormatEnum.json.name())) {
             httpPut.setHeader("strip_outer_array", "true");
-            //to solve the error : The size of this batch exceed the max size [104857600]  of json type data. Split the file, or use 'read_json_by_line'
-            httpPut.setHeader("read_json_by_line","true");
         }
         return httpPut;
     }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/DorisStreamLoad.java
@@ -73,33 +73,12 @@ public class DorisStreamLoad implements Serializable {
     private LoadingCache<String, List<BackendV2.BackendRowV2>> cache;
     private DataFormat dataFormat;
 
-
-    public DorisStreamLoad(SparkSettings settings) throws StreamLoadException {
-        String[] dbTable = settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
-        this.db = dbTable[0];
-        this.tbl = dbTable[1];
-        this.user = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_USER);
-        this.passwd = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD);
-        this.authEncoded = getAuthEncoded(user, passwd);
-        this.columns = settings.getProperty(ConfigurationOptions.DORIS_WRITE_FIELDS);
-
-        this.maxFilterRatio = settings.getProperty(ConfigurationOptions.DORIS_MAX_FILTER_RATIO);
-        this.streamLoadProp = getStreamLoadProp(settings);
-        cache = CacheBuilder.newBuilder()
-                .expireAfterWrite(cacheExpireTimeout, TimeUnit.MINUTES)
-                .build(new BackendCacheLoader(settings));
-        String formatType = this.streamLoadProp.getOrDefault("format",FormatEnum.csv.name());
-        dataFormat = DataFormatFactory.getDataFormat(formatType,null,this.streamLoadProp);
-    }
-
     public DorisStreamLoad(SparkSettings settings, String[] dfColumns) throws StreamLoadException {
         String[] dbTable = settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
         this.db = dbTable[0];
         this.tbl = dbTable[1];
         this.user = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_USER);
         this.passwd = settings.getProperty(ConfigurationOptions.DORIS_REQUEST_AUTH_PASSWORD);
-
-
         this.authEncoded = getAuthEncoded(user, passwd);
         this.columns = settings.getProperty(ConfigurationOptions.DORIS_WRITE_FIELDS);
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/CsvDataFormat.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/CsvDataFormat.java
@@ -1,0 +1,34 @@
+package org.apache.doris.spark.format;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CsvDataFormat extends DataFormat{
+
+    private String FIELD_DELIMITER;
+    private String LINE_DELIMITER;
+    private String NULL_VALUE = "\\N";
+
+    public CsvDataFormat(String[] dfColumns, Map<String, String> settings) {
+        super(FormatEnum.csv.name(),dfColumns, settings);
+        FIELD_DELIMITER = this.settings.getOrDefault("column_separator","\t");
+        LINE_DELIMITER = this.settings.getOrDefault("line_delimiter","\n");
+    }
+
+
+    protected String listToString(List<List<Object>> rows) {
+        return rows.stream().map(row ->
+                row.stream().map(field ->
+                        (field == null) ? NULL_VALUE : field.toString()
+                ).collect(Collectors.joining(FIELD_DELIMITER))
+        ).collect(Collectors.joining(LINE_DELIMITER));
+    }
+
+    @Override
+    public List<String> wtriteAsString(List<List<Object>> rows) throws Exception {
+        return Lists.newArrayList(listToString(rows));
+    }
+}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormat.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormat.java
@@ -1,0 +1,25 @@
+package org.apache.doris.spark.format;
+
+import java.util.List;
+import java.util.Map;
+
+public abstract class DataFormat {
+
+    protected String type;
+
+    protected String[] dfColumns;
+
+    protected Map<String, String> settings;
+
+    public DataFormat(String type, String[] dfColumns, Map<String, String> settings) {
+        this.type = type;
+        this.dfColumns = dfColumns;
+        this.settings = settings;
+    }
+
+    public abstract List<String> wtriteAsString(List<List<Object>> rows) throws Exception;
+
+    public String getType() {
+        return type;
+    }
+}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormat.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormat.java
@@ -1,9 +1,10 @@
 package org.apache.doris.spark.format;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-public abstract class DataFormat {
+public abstract class DataFormat implements Serializable {
 
     protected String type;
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormatFactory.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormatFactory.java
@@ -4,9 +4,10 @@ import org.apache.doris.spark.exception.StreamLoadException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.util.Map;
 
-public class DataFormatFactory {
+public class DataFormatFactory implements Serializable {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataFormatFactory.class);
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormatFactory.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/DataFormatFactory.java
@@ -1,0 +1,28 @@
+package org.apache.doris.spark.format;
+
+import org.apache.doris.spark.exception.StreamLoadException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class DataFormatFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataFormatFactory.class);
+
+    public static DataFormat getDataFormat(String type,String[] dfColumns, Map<String,String> settings) throws StreamLoadException {
+        DataFormat dataFormat;
+        if(type.equalsIgnoreCase(FormatEnum.csv.name())){
+            dataFormat = new CsvDataFormat(dfColumns,settings);
+        }else if(type.equalsIgnoreCase(FormatEnum.json.name())){
+            dataFormat = new JsonDataFormat(dfColumns,settings);
+        }else{
+            throw new StreamLoadException(String.format("Unsupported data format in stream load: %s.", type));
+        }
+        LOG.info("get {} data format",type);
+        return dataFormat;
+    }
+
+
+
+}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/FormatEnum.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/FormatEnum.java
@@ -1,0 +1,9 @@
+package org.apache.doris.spark.format;
+
+
+public enum FormatEnum {
+
+    json,
+    csv
+
+}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/JsonDataFormat.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/JsonDataFormat.java
@@ -19,6 +19,7 @@ public class JsonDataFormat extends DataFormat{
         List<Map<Object, Object>> dataList = new ArrayList<>();
         for (List<Object> row : rows) {
             Map<Object, Object> dataMap = new HashMap<>();
+            // when created from CachedDorisStreamLoadClient, the dfColumns is null
             if (dfColumns!= null && dfColumns.length != row.size()) {
                 throw new StreamLoadException("The number of configured columns does not match the number of data columns.");
             }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/format/JsonDataFormat.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/format/JsonDataFormat.java
@@ -1,0 +1,36 @@
+package org.apache.doris.spark.format;
+
+import org.apache.doris.spark.exception.StreamLoadException;
+import org.apache.doris.spark.util.ListUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JsonDataFormat extends DataFormat{
+
+
+    public JsonDataFormat(String[] dfColumns, Map<String, String> settings) {
+        super(FormatEnum.json.name(),dfColumns, settings);
+    }
+
+    @Override
+    public List<String> wtriteAsString(List<List<Object>> rows) throws Exception{
+        List<Map<Object, Object>> dataList = new ArrayList<>();
+        for (List<Object> row : rows) {
+            Map<Object, Object> dataMap = new HashMap<>();
+            if (dfColumns!= null && dfColumns.length != row.size()) {
+                throw new StreamLoadException("The number of configured columns does not match the number of data columns.");
+            }
+            for (int i = 0; i < dfColumns.length; i++) {
+                dataMap.put(dfColumns[i], row.get(i));
+            }
+            dataList.add(dataMap);
+        }
+        // splits large collections to normal collection to avoid the "Requested array size exceeds VM limit" exception
+        return ListUtils.getSerializedList(dataList);
+
+    }
+
+
+}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,19 +41,18 @@ public class ListUtils {
      * recursively splits large collections to normal collection and serializes the collection
      * @param batch
      * @param result
-     * @throws JsonProcessingException
      */
-    public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result) throws JsonProcessingException {
+    public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result) {
 
         // if an error occurred in the batch call to getBytes ,average divide the batch
         try {
             //the "Requested array size exceeds VM limit" exception occurs when the collection is large
-            String serializedResult = (new ObjectMapper()).writeValueAsString(batch);
-            serializedResult.getBytes("UTF-8");
+            String serializedResult = ObjectMapperUtils.writeValueAsString(batch);
+            serializedResult.getBytes(StandardCharsets.UTF_8);
             result.add(serializedResult);
             return;
         } catch (Throwable error) {
-            LOG.error("getBytes error:{} ,average divide the collection", error);
+            LOG.error("getBytes error,average divide the collection", error);
         }
         for (List<Map<Object, Object>> avgSubCollection : getAvgSubCollections(batch)) {
             divideAndSerialize(avgSubCollection, result);

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
@@ -43,10 +43,11 @@ public class ListUtils {
      * @throws JsonProcessingException
      */
     public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result) throws JsonProcessingException {
-        String serializedResult = (new ObjectMapper()).writeValueAsString(batch);
+
         // if an error occurred in the batch call to getBytes ,average divide the batch
         try {
             //the "Requested array size exceeds VM limit" exception occurs when the collection is large
+            String serializedResult = (new ObjectMapper()).writeValueAsString(batch);
             serializedResult.getBytes("UTF-8");
             result.add(serializedResult);
             return;

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ObjectMapperUtils.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ObjectMapperUtils.java
@@ -1,0 +1,16 @@
+package org.apache.doris.spark.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+public class ObjectMapperUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String writeValueAsString(Object value) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(value);
+    }
+
+
+}

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisSourceProvider.scala
@@ -69,6 +69,8 @@ private[sql] class DorisSourceProvider extends DataSourceRegister
 
     logger.info(s"maxRowCount ${maxRowCount}")
     logger.info(s"maxRetryTimes ${maxRetryTimes}")
+    logger.info(s"sinkTaskUseRepartition ${sinkTaskUseRepartition}")
+    logger.info(s"sinkTaskPartitionSize ${sinkTaskPartitionSize}")
     logger.info(s"batchInterVarMs ${batchInterValMs}")
 
     var resultRdd = data.rdd


### PR DESCRIPTION
# Proposed changes
1. [improve] improve the sink format(json/csv) handle logic by factory pattern
2. [improve] add read_json_by_line:ture to HttpPut header to avoid [the size of this batch exceed the max size [104857600]  of json type data] when sink format is json
3. [improve] remove some unuses construnction method of DorisStreamLoad class
4. [improve] build a singleton ObjectMapper and reuse it instead of creating a new instance every time

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
