### PR TITLE
[feature] Add the date format parameter to control the output of timestamp type data

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/CachedDorisStreamLoadClient.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/CachedDorisStreamLoadClient.java
@@ -39,25 +39,20 @@ public class CachedDorisStreamLoadClient {
     static {
         dorisStreamLoadLoadingCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(cacheExpireTimeout, TimeUnit.SECONDS)
-                .removalListener(new RemovalListener<Object, Object>() {
-                    @Override
-                    public void onRemoval(RemovalNotification<Object, Object> removalNotification) {
-                        //do nothing
-                    }
+                .removalListener(removalNotification -> {
+                    //do nothing
                 })
                 .build(
                         new CacheLoader<SparkSettings, DorisStreamLoad>() {
                             @Override
-                            public DorisStreamLoad load(SparkSettings sparkSettings) throws IOException, DorisException {
-                                DorisStreamLoad dorisStreamLoad = new DorisStreamLoad(sparkSettings);
-                                return dorisStreamLoad;
+                            public DorisStreamLoad load(SparkSettings sparkSettings) {
+                                return new DorisStreamLoad(sparkSettings);
                             }
                         }
                 );
     }
 
     public static DorisStreamLoad getOrCreate(SparkSettings settings) throws ExecutionException {
-        DorisStreamLoad dorisStreamLoad = dorisStreamLoadLoadingCache.get(settings);
-        return dorisStreamLoad;
+        return dorisStreamLoadLoadingCache.get(settings);
     }
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -90,4 +90,15 @@ public interface ConfigurationOptions {
 
     int DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT = 50;
 
+    /**
+     * Format timestamp type data into a string of the specified format
+     */
+    String DORIS_SINK_ENABLE_DATE_FORMAT = "doris.sink.enable-date-format";
+
+    String DORIS_SINK_ENABLE_DATE_FORMAT_DEFAULT = "true";
+
+    String DORIS_SINK_DATE_FORMAT_PATTERN = "doris.sink.date-format-pattern";
+
+    String DORIS_SINK_DATE_FORMAT_PATTERN_DEFAULT = "yyyy-MM-dd HH:mm:ss.SSS";
+
 }

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/util/TestListUtils.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/util/TestListUtils.java
@@ -34,9 +34,9 @@ public class TestListUtils {
             Map<Object, Object> entity = new HashMap<>();
             batch.add(entity);
         }
-        Assert.assertEquals(ListUtils.getSerializedList(batch).size(), 1);
+        Assert.assertEquals(ListUtils.getSerializedList(batch, null).size(), 1);
 
-        Assert.assertEquals(ListUtils.getSerializedList(new ArrayList<>()).size(), 1);
+        Assert.assertEquals(ListUtils.getSerializedList(new ArrayList<>(), null).size(), 1);
 
     }
 }


### PR DESCRIPTION
…stamp type

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. Add new parameters `doris.sink.enable-date-format` and `doris.sink.date-format-pattern` to format timestamp type data to avoid loading failure when loading datetime column with not null attribute.
2. Reorganized the constructor of the `DorisStreamLoad` class.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
