### PR TITLE
[improvement] add new param for ignored type

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -90,6 +90,11 @@ public interface ConfigurationOptions {
 
     int DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT = 50;
 
+    /**
+     * set types to ignore, split by comma
+     * e.g.
+     * "doris.ignore-type"="bitmap,hll"
+     */
     String DORIS_IGNORE_TYPE = "doris.ignore-type";
 
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -90,4 +90,6 @@ public interface ConfigurationOptions {
 
     int DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT = 50;
 
+    String DORIS_IGNORE_TYPE = "doris.ignore-type";
+
 }

--- a/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSchemaUtils.scala
+++ b/spark-doris-connector/src/test/scala/org/apache/doris/spark/sql/TestSchemaUtils.scala
@@ -41,7 +41,7 @@ class TestSchemaUtils extends ExpectedExceptionTest {
     fields :+= DataTypes.createStructField("k1", DataTypes.ByteType, true)
     fields :+= DataTypes.createStructField("k5", DataTypes.LongType, true)
     val expected = DataTypes.createStructType(fields.asJava)
-    Assert.assertEquals(expected, SchemaUtils.convertToStruct("k1,k5", schema))
+    Assert.assertEquals(expected, SchemaUtils.convertToStruct(schema, "k1,k5", null))
   }
 
   @Test
@@ -93,4 +93,24 @@ class TestSchemaUtils extends ExpectedExceptionTest {
 
     Assert.assertEquals(expected, SchemaUtils.convertToSchema(Seq(k1, k2)))
   }
+
+  @Test
+  def testIgnoreTypes(): Unit = {
+
+    val schema = new Schema
+    schema.setStatus(200)
+    val col1 = new Field("col1", "TINYINT", "", 0, 0, "")
+    val col2 = new Field("col2", "BITMAP", "", 0, 0, "")
+    val col3 = new Field("col3", "HLL", "", 0, 0, "")
+    schema.put(col1)
+    schema.put(col2)
+    schema.put(col3)
+
+    var fields = List[StructField]()
+    fields :+= DataTypes.createStructField("col1", DataTypes.ByteType, true)
+    val expected = DataTypes.createStructType(fields.asJava)
+    Assert.assertEquals(expected, SchemaUtils.convertToStruct(schema, null, "bitmap,hll"))
+
+  }
+
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Some types do not support reading, but can be written by setting column mapping, such as bitmap, hll.
When writing in sql by creating a temporary view, you need to read the schema of the corresponding table, and an exception with message 'unsupported type' will be thrown.
So add the parameter `doris.ignore-type` to specify the type you want to ignore, and the columns of the corresponding type will be ignored when getting the schema.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
