### PR TITLE
[feature] support two phase commit

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -97,4 +97,7 @@ public interface ConfigurationOptions {
      */
     String DORIS_IGNORE_TYPE = "doris.ignore-type";
 
+    String DORIS_SINK_ENABLE_2PC = "doris.sink.enable-2pc";
+    boolean DORIS_SINK_ENABLE_2PC_DEFAULT = false;
+
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/Settings.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/Settings.java
@@ -62,6 +62,17 @@ public abstract class Settings {
         return defaultValue;
     }
 
+    public Boolean getBooleanProperty(String name) {
+        return getBooleanProperty(name, null);
+    }
+
+    public Boolean getBooleanProperty(String name, Boolean defaultValue) {
+        if (getProperty(name) != null) {
+            return Boolean.valueOf(getProperty(name));
+        }
+        return defaultValue;
+    }
+
     public Settings merge(Properties properties) {
         if (properties == null || properties.isEmpty()) {
             return this;

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -23,8 +23,10 @@ import org.apache.doris.spark.rest.RestService;
 import org.apache.doris.spark.rest.models.BackendV2;
 import org.apache.doris.spark.rest.models.RespContent;
 import org.apache.doris.spark.util.ListUtils;
+import org.apache.doris.spark.util.ResponseUtil;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -34,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.StringEntity;
@@ -74,9 +77,14 @@ public class DorisStreamLoad implements Serializable {
 
     private final static List<String> DORIS_SUCCESS_STATUS = new ArrayList<>(Arrays.asList("Success", "Publish Timeout"));
     private static String loadUrlPattern = "http://%s/api/%s/%s/_stream_load?";
+
+    private static String abortUrlPattern = "http://%s/api/%s/%s/_stream_load_2pc?";
+
     private String user;
     private String passwd;
     private String loadUrlStr;
+
+    private String abortUrlStr;
     private String db;
     private String tbl;
     private String authEncoded;
@@ -121,13 +129,14 @@ public class DorisStreamLoad implements Serializable {
         }
         return loadUrlStr;
     }
+
     private CloseableHttpClient getHttpClient() {
         HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
                 .disableRedirectHandling();
         return httpClientBuilder.build();
     }
 
-    private HttpPut getHttpPut(String label, String loadUrlStr) {
+    private HttpPut getHttpPut(String label, String loadUrlStr, Boolean enable2PC) {
         HttpPut httpPut = new HttpPut(loadUrlStr);
         httpPut.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + authEncoded);
         httpPut.setHeader(HttpHeaders.EXPECT, "100-continue");
@@ -138,6 +147,9 @@ public class DorisStreamLoad implements Serializable {
         }
         if (StringUtils.isNotBlank(maxFilterRatio)) {
             httpPut.setHeader("max_filter_ratio", maxFilterRatio);
+        }
+        if (enable2PC) {
+            httpPut.setHeader("two_phase_commit", "true");
         }
         if (MapUtils.isNotEmpty(streamLoadProp)) {
             streamLoadProp.forEach(httpPut::setHeader);
@@ -164,94 +176,162 @@ public class DorisStreamLoad implements Serializable {
         }
     }
 
-    public String listToString(List<List<Object>> rows) {
-        return rows.stream().map(row ->
-                row.stream().map(field -> field == null ? NULL_VALUE : field.toString())
-                        .collect(Collectors.joining(FIELD_DELIMITER))
-        ).collect(Collectors.joining(LINE_DELIMITER));
-    }
+    public List<Integer> loadV2(List<List<Object>> rows, String[] dfColumns, Boolean enable2PC) throws StreamLoadException, JsonProcessingException {
 
+        List<String> loadData = parseLoadData(rows, dfColumns);
+        List<Integer> txnIds = new ArrayList<>(loadData.size());
 
-    public void loadV2(List<List<Object>> rows, String[] dfColumns) throws StreamLoadException, JsonProcessingException {
-        if (fileType.equals("csv")) {
-            load(listToString(rows));
-        } else if(fileType.equals("json")) {
-            List<Map<Object, Object>> dataList = new ArrayList<>();
-            try {
-                for (List<Object> row : rows) {
-                    Map<Object, Object> dataMap = new HashMap<>();
-                    if (dfColumns.length == row.size()) {
-                        for (int i = 0; i < dfColumns.length; i++) {
-                            Object col = row.get(i);
-                            if (col instanceof Timestamp) {
-                                dataMap.put(dfColumns[i], col.toString());
-                                continue;
-                            }
-                            dataMap.put(dfColumns[i], col);
-                        }
-                    }
-                    dataList.add(dataMap);
+        try {
+            for (String data : loadData) {
+                txnIds.add(load(data, enable2PC));
+            }
+        } catch (StreamLoadException e) {
+            if (enable2PC) {
+                LOG.error("load batch failed, abort previously pre-committed transactions");
+                for (Integer txnId : txnIds) {
+                    abort(txnId);
                 }
-            } catch (Exception e) {
-                throw new StreamLoadException("The number of configured columns does not match the number of data columns.");
             }
-            // splits large collections to normal collection to avoid the "Requested array size exceeds VM limit" exception
-            List<String> serializedList = ListUtils.getSerializedList(dataList, readJsonByLine ? LINE_DELIMITER : null);
-            for (String serializedRows : serializedList) {
-                load(serializedRows);
-            }
-        } else {
-            throw new StreamLoadException(String.format("Unsupported file format in stream load: %s.", fileType));
+            throw e;
         }
+
+        return txnIds;
+
     }
 
-    public void load(String value) throws StreamLoadException {
-        LoadResponse loadResponse = loadBatch(value);
-        if (loadResponse.status != HttpStatus.SC_OK) {
-            LOG.info("Streamload Response HTTP Status Error:{}", loadResponse);
-            throw new StreamLoadException("stream load error: " + loadResponse.respContent);
-        } else {
-            ObjectMapper obj = new ObjectMapper();
-            try {
-                RespContent respContent = obj.readValue(loadResponse.respContent, RespContent.class);
-                if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
-                    LOG.error("Streamload Response RES STATUS Error:{}", loadResponse);
-                    throw new StreamLoadException("stream load error: " + loadResponse);
-                }
-                LOG.info("Streamload Response:{}", loadResponse);
-            } catch (IOException e) {
-                throw new StreamLoadException(e);
-            }
-        }
-    }
+    public int load(String value, Boolean enable2PC) throws StreamLoadException {
 
-    private LoadResponse loadBatch(String value) {
-        Calendar calendar = Calendar.getInstance();
-        String label = String.format("spark_streamload_%s%02d%02d_%02d%02d%02d_%s",
-                calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH),
-                calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND),
-                UUID.randomUUID().toString().replaceAll("-", ""));
+        String label = generateLoadLabel();
 
+        LoadResponse loadResponse;
         int responseHttpStatus = -1;
         try (CloseableHttpClient httpClient = getHttpClient()) {
             String loadUrlStr = String.format(loadUrlPattern, getBackend(), db, tbl);
-            LOG.debug("Streamload Request:{} ,Body:{}", loadUrlStr, value);
-            //only to record the BE node in case of an exception
+            LOG.debug("Stream load Request:{} ,Body:{}", loadUrlStr, value);
+            // only to record the BE node in case of an exception
             this.loadUrlStr = loadUrlStr;
 
-            HttpPut httpPut = getHttpPut(label, loadUrlStr);
+            HttpPut httpPut = getHttpPut(label, loadUrlStr, enable2PC);
             httpPut.setEntity(new StringEntity(value, StandardCharsets.UTF_8));
             HttpResponse httpResponse = httpClient.execute(httpPut);
             responseHttpStatus = httpResponse.getStatusLine().getStatusCode();
             String respMsg = httpResponse.getStatusLine().getReasonPhrase();
             String response = EntityUtils.toString(new BufferedHttpEntity(httpResponse.getEntity()), StandardCharsets.UTF_8);
-            return new LoadResponse(responseHttpStatus, respMsg, response);
+            loadResponse = new LoadResponse(responseHttpStatus, respMsg, response);
         } catch (IOException e) {
             e.printStackTrace();
-            String err = "http request exception,load url : " + loadUrlStr + ",failed to execute spark streamload with label: " + label;
+            String err = "http request exception,load url : " + loadUrlStr +
+                    ",failed to execute spark stream load with label: " + label;
             LOG.warn(err, e);
-            return new LoadResponse(responseHttpStatus, e.getMessage(), err);
+            loadResponse = new LoadResponse(responseHttpStatus, e.getMessage(), err);
         }
+
+        if (loadResponse.status != HttpStatus.SC_OK) {
+            LOG.info("Stream load Response HTTP Status Error:{}", loadResponse);
+            // throw new StreamLoadException("stream load error: " + loadResponse.respContent);
+            throw new StreamLoadException("stream load error");
+        } else {
+            ObjectMapper obj = new ObjectMapper();
+            try {
+                RespContent respContent = obj.readValue(loadResponse.respContent, RespContent.class);
+                if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
+                    LOG.error("Stream load Response RES STATUS Error:{}", loadResponse);
+                    throw new StreamLoadException("stream load error");
+                }
+                LOG.info("Stream load Response:{}", loadResponse);
+                return respContent.getTxnId();
+            } catch (IOException e) {
+                throw new StreamLoadException(e);
+            }
+        }
+
+    }
+
+    public void commit(int txnId) throws StreamLoadException {
+
+        try (CloseableHttpClient client = getHttpClient()) {
+
+            String backend = getBackend();
+            String abortUrl = String.format(abortUrlPattern, backend, db, tbl);
+            HttpPut httpPut = new HttpPut(abortUrl);
+            httpPut.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + authEncoded);
+            httpPut.setHeader(HttpHeaders.EXPECT, "100-continue");
+            httpPut.setHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
+            httpPut.setHeader("txn_operation", "commit");
+            httpPut.setHeader("txn_id", String.valueOf(txnId));
+
+            CloseableHttpResponse response = client.execute(httpPut);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200 || response.getEntity() == null) {
+                LOG.warn("abort transaction response: " + response.getStatusLine().toString());
+                throw new StreamLoadException("Fail to abort transaction " + txnId + " with url " + abortUrlStr);
+            }
+
+            statusCode = response.getStatusLine().getStatusCode();
+            String reasonPhrase = response.getStatusLine().getReasonPhrase();
+            if (statusCode != 200) {
+                LOG.warn("commit failed with {}, reason {}", backend, reasonPhrase);
+            }
+
+            if (statusCode != 200) {
+                throw new StreamLoadException("stream load error: " + reasonPhrase);
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            if (response.getEntity() != null) {
+                String loadResult = EntityUtils.toString(response.getEntity());
+                Map<String, String> res = mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>() {
+                });
+                if (res.get("status").equals("Fail") && !ResponseUtil.isCommitted(res.get("msg"))) {
+                    throw new StreamLoadException("Commit failed " + loadResult);
+                } else {
+                    LOG.info("load result {}", loadResult);
+                }
+            }
+
+        } catch (IOException e) {
+            throw new StreamLoadException(e);
+        }
+
+    }
+
+    public void abort(int txnId) throws StreamLoadException {
+
+        LOG.info("start abort transaction {}.", txnId);
+
+        try (CloseableHttpClient client = getHttpClient()) {
+            String abortUrl = String.format(abortUrlPattern, getBackend(), db, tbl);
+            HttpPut httpPut = new HttpPut(abortUrl);
+            httpPut.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + authEncoded);
+            httpPut.setHeader(HttpHeaders.EXPECT, "100-continue");
+            httpPut.setHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
+            httpPut.setHeader("txn_operation", "abort");
+            httpPut.setHeader("txn_id", String.valueOf(txnId));
+
+            CloseableHttpResponse response = client.execute(httpPut);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200 || response.getEntity() == null) {
+                LOG.warn("abort transaction response: " + response.getStatusLine().toString());
+                throw new StreamLoadException("Fail to abort transaction " + txnId + " with url " + abortUrlStr);
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            String loadResult = EntityUtils.toString(response.getEntity());
+            Map<String, String> res = mapper.readValue(loadResult, new TypeReference<HashMap<String, String>>(){});
+            if (!"Success".equals(res.get("status"))) {
+                if (ResponseUtil.isCommitted(res.get("msg"))) {
+                    throw new StreamLoadException("try abort committed transaction, " +
+                            "do you recover from old savepoint?");
+                }
+                LOG.warn("Fail to abort transaction. txnId: {}, error: {}", txnId, res.get("msg"));
+            }
+
+        } catch (IOException e) {
+            throw new StreamLoadException(e);
+        }
+
+        LOG.info("abort transaction {} succeed.", txnId);
+
     }
 
     public Map<String, String> getStreamLoadProp(SparkSettings sparkSettings) {
@@ -268,7 +348,7 @@ public class DorisStreamLoad implements Serializable {
 
     private String getBackend() {
         try {
-            //get backends from cache
+            // get backends from cache
             List<BackendV2.BackendRowV2> backends = cache.get("backends");
             Collections.shuffle(backends);
             BackendV2.BackendRowV2 backend = backends.get(0);
@@ -301,6 +381,60 @@ public class DorisStreamLoad implements Serializable {
 
     }
 
+    private List<String> parseLoadData(List<List<Object>> rows, String[] dfColumns) throws StreamLoadException, JsonProcessingException {
+
+        List<String> loadDataList;
+
+        switch (fileType.toUpperCase()) {
+
+            case "CSV":
+                loadDataList = Collections.singletonList(rows.stream().map(row ->
+                        row.stream().map(field -> field == null ? NULL_VALUE : field.toString())
+                                .collect(Collectors.joining(FIELD_DELIMITER))
+                ).collect(Collectors.joining(LINE_DELIMITER)));
+                break;
+            case "JSON":
+                List<Map<Object, Object>> dataList = new ArrayList<>();
+                try {
+                    for (List<Object> row : rows) {
+                        Map<Object, Object> dataMap = new HashMap<>();
+                        if (dfColumns.length == row.size()) {
+                            for (int i = 0; i < dfColumns.length; i++) {
+                                Object col = row.get(i);
+                                if (col instanceof Timestamp) {
+                                    dataMap.put(dfColumns[i], col.toString());
+                                    continue;
+                                }
+                                dataMap.put(dfColumns[i], col);
+                            }
+                        }
+                        dataList.add(dataMap);
+                    }
+                } catch (Exception e) {
+                    throw new StreamLoadException("The number of configured columns does not match the number of data columns.");
+                }
+                // splits large collections to normal collection to avoid the "Requested array size exceeds VM limit" exception
+                loadDataList = ListUtils.getSerializedList(dataList, readJsonByLine ? LINE_DELIMITER : null);
+                break;
+            default:
+                throw new StreamLoadException(String.format("Unsupported file format in stream load: %s.", fileType));
+
+        }
+
+        return loadDataList;
+
+    }
+
+    private String generateLoadLabel() {
+
+        Calendar calendar = Calendar.getInstance();
+        return String.format("spark_streamload_%s%02d%02d_%02d%02d%02d_%s",
+                calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.DAY_OF_MONTH),
+                calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), calendar.get(Calendar.SECOND),
+                UUID.randomUUID().toString().replaceAll("-", ""));
+
+    }
+
     private String escapeString(String hexData) {
         if (hexData.startsWith("\\x") || hexData.startsWith("\\X")) {
             try {
@@ -314,7 +448,7 @@ public class DorisStreamLoad implements Serializable {
                 }
                 return stringBuilder.toString();
             } catch (Exception e) {
-                throw new RuntimeException("escape column_separator or line_delimiter error.{}" , e);
+                throw new RuntimeException("escape column_separator or line_delimiter error.{}", e);
             }
         }
         return hexData;

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -255,17 +255,14 @@ public class DorisStreamLoad implements Serializable {
             CloseableHttpResponse response = client.execute(httpPut);
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != 200 || response.getEntity() == null) {
-                LOG.warn("abort transaction response: " + response.getStatusLine().toString());
-                throw new StreamLoadException("Fail to abort transaction " + txnId + " with url " + abortUrlStr);
+                LOG.warn("commit transaction response: " + response.getStatusLine().toString());
+                throw new StreamLoadException("Fail to commit transaction " + txnId + " with url " + abortUrl);
             }
 
             statusCode = response.getStatusLine().getStatusCode();
             String reasonPhrase = response.getStatusLine().getReasonPhrase();
             if (statusCode != 200) {
                 LOG.warn("commit failed with {}, reason {}", backend, reasonPhrase);
-            }
-
-            if (statusCode != 200) {
                 throw new StreamLoadException("stream load error: " + reasonPhrase);
             }
 
@@ -304,7 +301,7 @@ public class DorisStreamLoad implements Serializable {
             int statusCode = response.getStatusLine().getStatusCode();
             if (statusCode != 200 || response.getEntity() == null) {
                 LOG.warn("abort transaction response: " + response.getStatusLine().toString());
-                throw new StreamLoadException("Fail to abort transaction " + txnId + " with url " + abortUrlStr);
+                throw new StreamLoadException("Fail to abort transaction " + txnId + " with url " + abortUrl);
             }
 
             ObjectMapper mapper = new ObjectMapper();

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/RespContent.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/rest/models/RespContent.java
@@ -75,6 +75,10 @@ public class RespContent {
     @JsonProperty(value = "ErrorURL")
     private String ErrorURL;
 
+    public int getTxnId() {
+        return TxnId;
+    }
+
     public String getStatus() {
         return Status;
     }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ResponseUtil.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ResponseUtil.java
@@ -1,0 +1,16 @@
+package org.apache.doris.spark.util;
+
+import java.util.regex.Pattern;
+
+public class ResponseUtil {
+    public static final Pattern LABEL_EXIST_PATTERN =
+            Pattern.compile("errCode = 2, detailMessage = Label \\[(.*)\\] " +
+                    "has already been used, relate to txn \\[(\\d+)\\]");
+    public static final Pattern COMMITTED_PATTERN =
+            Pattern.compile("errCode = 2, detailMessage = transaction \\[(\\d+)\\] " +
+                    "is already \\b(COMMITTED|committed|VISIBLE|visible)\\b, not pre-committed.");
+
+    public static boolean isCommitted(String msg) {
+       return COMMITTED_PATTERN.matcher(msg).matches();
+    }
+}

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ResponseUtil.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ResponseUtil.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.spark.util;
 
 import java.util.regex.Pattern;

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
@@ -1,0 +1,59 @@
+package org.apache.doris.spark.listener
+
+import org.apache.doris.spark.load.DorisStreamLoad
+import org.apache.doris.spark.sql.Utils
+import org.apache.spark.scheduler._
+import org.apache.spark.util.CollectionAccumulator
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.time.Duration
+import scala.collection.mutable
+import scala.util.{Failure, Success}
+
+class DorisTransactionListener(acc: CollectionAccumulator[Int], dorisStreamLoad: DorisStreamLoad)
+  extends SparkListener {
+
+  val logger: Logger = LoggerFactory.getLogger(classOf[DorisTransactionListener])
+
+  override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
+    val txnIds = acc.value
+    val failedTxnIds = mutable.Buffer[Int]()
+    jobEnd.jobResult match {
+      // if job succeed, commit all transactions
+      case JobSucceeded =>
+        logger.info("job run succeed, start commit transactions")
+        txnIds.forEach(txnId =>
+          Utils.retry(3, Duration.ofSeconds(1), logger) {
+            dorisStreamLoad.commit(txnId)
+          } match {
+            case Success(_) =>
+            case Failure(exception) =>
+              failedTxnIds += txnId
+              logger.error("commit transaction failed, exception {}", exception.getMessage)
+          })
+        if (failedTxnIds.nonEmpty) {
+          logger.error("uncommitted txn ids: {}", failedTxnIds.mkString(","))
+        } else {
+          logger.info("commit transaction succeed")
+        }
+      // if job failed, abort all pre committed transactions
+      case _ =>
+        logger.info("job run failed, start commit transactions")
+        txnIds.forEach(txnId =>
+          Utils.retry(3, Duration.ofSeconds(1), logger) {
+            dorisStreamLoad.abort(txnId)
+          } match {
+            case Success(_) =>
+            case Failure(exception) =>
+              failedTxnIds += txnId
+              logger.error("abort transaction failed, exception {}", exception.getMessage)
+          })
+        if (failedTxnIds.nonEmpty) {
+          logger.error("not aborted txn ids: {}", failedTxnIds.mkString(","))
+        } else {
+          logger.info("aborted transaction succeed")
+        }
+    }
+  }
+
+}

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.spark.listener
 
 import org.apache.doris.spark.load.DorisStreamLoad
@@ -7,6 +24,7 @@ import org.apache.spark.util.CollectionAccumulator
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.time.Duration
+import java.util
 import scala.collection.mutable
 import scala.util.{Failure, Success}
 
@@ -16,7 +34,7 @@ class DorisTransactionListener(acc: CollectionAccumulator[Int], dorisStreamLoad:
   val logger: Logger = LoggerFactory.getLogger(classOf[DorisTransactionListener])
 
   override def onJobEnd(jobEnd: SparkListenerJobEnd): Unit = {
-    val txnIds = acc.value
+    val txnIds: util.List[Int] = acc.value
     val failedTxnIds = mutable.Buffer[Int]()
     jobEnd.jobResult match {
       // if job succeed, commit all transactions

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/Utils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/Utils.scala
@@ -174,7 +174,7 @@ private[spark] object Utils {
         Success(result)
       case Failure(exception: T) if retryTimes > 0 =>
         logger.warn(s"Execution failed caused by: ", exception)
-        logger.warn(s"$retryTimes times retry remaining, the next will be in ${interval.toMillis}ms")
+        logger.warn(s"$retryTimes times retry remaining, the next attempt will be in ${interval.toMillis} ms")
         LockSupport.parkNanos(interval.toNanos)
         retry(retryTimes - 1, interval, logger)(f)
       case Failure(exception) => Failure(exception)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
@@ -79,7 +79,7 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
       Utils.retry[util.List[Integer], Exception](maxRetryTimes, Duration.ofMillis(batchInterValMs.toLong), logger) {
         dorisStreamLoader.loadV2(batch.toList.asJava, dfColumns, enable2PC)
       } match {
-        case Success(txnIds) => if (enable2PC) txnIds.forEach(txnId => successTxnAcc.add(txnId))
+        case Success(txnIds) => if (enable2PC) txnIds.asScala.foreach(txnId => successTxnAcc.add(txnId))
         case Failure(e) =>
           throw new IOException(
             s"Failed to load batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", e)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
@@ -29,6 +29,7 @@ import java.time.Duration
 import java.util
 import java.util.Objects
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.{Failure, Success}
 
 class DorisWriter(settings: SparkSettings) extends Serializable {
@@ -53,9 +54,9 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
   def write(dataFrame: DataFrame): Unit = {
 
     val sc = dataFrame.sqlContext.sparkContext
-    val successTxnAcc = sc.collectionAccumulator[Int]("successTxnAcc")
+    val preCommittedTxnAcc = sc.collectionAccumulator[Int]("preCommittedTxnAcc")
     if (enable2PC) {
-      sc.addSparkListener(new DorisTransactionListener(successTxnAcc, dorisStreamLoader))
+      sc.addSparkListener(new DorisTransactionListener(preCommittedTxnAcc, dorisStreamLoader))
     }
 
     var resultRdd = dataFrame.rdd
@@ -79,8 +80,24 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
       Utils.retry[util.List[Integer], Exception](maxRetryTimes, Duration.ofMillis(batchInterValMs.toLong), logger) {
         dorisStreamLoader.loadV2(batch.toList.asJava, dfColumns, enable2PC)
       } match {
-        case Success(txnIds) => if (enable2PC) txnIds.asScala.foreach(txnId => successTxnAcc.add(txnId))
+        case Success(txnIds) => if (enable2PC) txnIds.asScala.foreach(txnId => preCommittedTxnAcc.add(txnId))
         case Failure(e) =>
+          if (enable2PC) {
+            // if task run failed, acc value will not be returned to driver,
+            // should abort all pre committed transactions inside the task
+            logger.info("load task failed, start aborting previously pre-committed transactions")
+            val abortFailedTxnIds = mutable.Buffer[Int]()
+            preCommittedTxnAcc.value.asScala.foreach(txnId => {
+              Utils.retry[Unit, Exception](3, Duration.ofSeconds(1), logger) {
+                dorisStreamLoader.abort(txnId)
+              } match {
+                case Success(_) =>
+                case Failure(_) => abortFailedTxnIds += txnId
+              }
+            })
+            if (abortFailedTxnIds.nonEmpty) logger.warn("not aborted txn ids: {}", abortFailedTxnIds.mkString(","))
+            preCommittedTxnAcc.reset()
+          }
           throw new IOException(
             s"Failed to load batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", e)
       }


### PR DESCRIPTION
# Proposed changes

Spark doris connector support two-phase commit.

Set the option `doris.sink.enable-2pc` to `true` to enable two-phase commit for stream load.

After enabled, the behavior is as follows:
Pre-submit stream load requests for each batch load, and then
1. When the job succeeds, all pre-committed transactions will be committed.
2. When the job fails, all pre-committed transactions will be aborted.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
