### PR TITLE
[fix] json format load default mode

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -114,6 +114,9 @@ public class DorisStreamLoad implements Serializable {
             boolean stripOuterArray = Boolean.parseBoolean(streamLoadProp.getOrDefault("strip_outer_array", "false"));
             if (readJsonByLine && stripOuterArray) {
                 throw new IllegalArgumentException("Only one of options 'read_json_by_line' and 'strip_outer_array' can be set to true");
+            } else if (!readJsonByLine && !stripOuterArray) {
+                LOG.info("set default json mode: strip_outer_array");
+                streamLoadProp.put("strip_outer_array", "true");
             }
         }
         LINE_DELIMITER = escapeString(streamLoadProp.getOrDefault("line_delimiter", "\n"));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Fixed the problem that there is no default parameter when `read_json_by_line` and `strip_outer_array` are not specified in json format.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
