### PR TITLE
convert date/datev2 to sql date and largeint into decimal(38,0)

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
@@ -20,7 +20,12 @@ package org.apache.doris.spark.serialization;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -30,6 +35,7 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
@@ -41,9 +47,12 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.Types;
+
 import org.apache.doris.sdk.thrift.TScanBatchResult;
 import org.apache.doris.spark.exception.DorisException;
 import org.apache.doris.spark.rest.models.Schema;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.spark.sql.types.Decimal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,7 +107,7 @@ public class RowBatch {
                             fieldVectors.size(), schema.size());
                     throw new DorisException("Load Doris data failed, schema size of fetch data is wrong.");
                 }
-                if (fieldVectors.size() == 0 || root.getRowCount() == 0) {
+                if (fieldVectors.isEmpty() || root.getRowCount() == 0) {
                     logger.debug("One batch in arrow has no data.");
                     continue;
                 }
@@ -190,6 +199,34 @@ public class RowBatch {
                             addValueToRow(rowIndex, fieldValue);
                         }
                         break;
+                    case "LARGEINT":
+                        Preconditions.checkArgument(mt.equals(Types.MinorType.FIXEDSIZEBINARY) ||
+                                mt.equals(Types.MinorType.VARCHAR), typeMismatchMessage(currentType, mt));
+                        if (mt.equals(Types.MinorType.FIXEDSIZEBINARY)) {
+                            FixedSizeBinaryVector largeIntVector = (FixedSizeBinaryVector) curFieldVector;
+                            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+                                if (largeIntVector.isNull(rowIndex)) {
+                                    addValueToRow(rowIndex, null);
+                                    continue;
+                                }
+                                byte[] bytes = largeIntVector.get(rowIndex);
+                                ArrayUtils.reverse(bytes);
+                                BigInteger largeInt = new BigInteger(bytes);
+                                addValueToRow(rowIndex, Decimal.apply(largeInt));
+                            }
+                        } else {
+                            VarCharVector largeIntVector = (VarCharVector) curFieldVector;
+                            for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+                                if (largeIntVector.isNull(rowIndex)) {
+                                    addValueToRow(rowIndex, null);
+                                    continue;
+                                }
+                                String stringValue = new String(largeIntVector.get(rowIndex));
+                                BigInteger largeInt = new BigInteger(stringValue);
+                                addValueToRow(rowIndex, Decimal.apply(largeInt));
+                            }
+                        }
+                        break;
                     case "FLOAT":
                         Preconditions.checkArgument(mt.equals(Types.MinorType.FLOAT4),
                                 typeMismatchMessage(currentType, mt));
@@ -257,9 +294,21 @@ public class RowBatch {
                         break;
                     case "DATE":
                     case "DATEV2":
+                        Preconditions.checkArgument(mt.equals(Types.MinorType.VARCHAR),
+                                typeMismatchMessage(currentType, mt));
+                        VarCharVector date = (VarCharVector) curFieldVector;
+                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+                            if (date.isNull(rowIndex)) {
+                                addValueToRow(rowIndex, null);
+                                continue;
+                            }
+                            String stringValue = new String(date.get(rowIndex));
+                            LocalDate localDate = LocalDate.parse(stringValue);
+                            addValueToRow(rowIndex, Date.valueOf(localDate));
+                        }
+                        break;
                     case "DATETIME":
                     case "DATETIMEV2":
-                    case "LARGEINT":
                     case "CHAR":
                     case "VARCHAR":
                     case "STRING":

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
@@ -102,14 +102,14 @@ private[spark] object SchemaUtils {
       case "BIGINT"          => DataTypes.LongType
       case "FLOAT"           => DataTypes.FloatType
       case "DOUBLE"          => DataTypes.DoubleType
-      case "DATE"            => DataTypes.StringType
-      case "DATEV2"          => DataTypes.StringType
+      case "DATE"            => DataTypes.DateType
+      case "DATEV2"          => DataTypes.DateType
       case "DATETIME"        => DataTypes.StringType
       case "DATETIMEV2"      => DataTypes.StringType
       case "BINARY"          => DataTypes.BinaryType
       case "DECIMAL"         => DecimalType(precision, scale)
       case "CHAR"            => DataTypes.StringType
-      case "LARGEINT"        => DataTypes.StringType
+      case "LARGEINT"        => DecimalType(38,0)
       case "VARCHAR"         => DataTypes.StringType
       case "JSONB"           => DataTypes.StringType
       case "DECIMALV2"       => DecimalType(precision, scale)

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
@@ -23,9 +23,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
+import java.text.DateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -261,7 +264,7 @@ public class TestRowBatch {
                 1L,
                 (float) 1.1,
                 (double) 1.1,
-                "2008-08-08",
+                Date.valueOf("2008-08-08"),
                 "2008-08-08 00:00:00",
                 Decimal.apply(1234L, 4, 2),
                 "char1"
@@ -275,7 +278,7 @@ public class TestRowBatch {
                 2L,
                 (float) 2.2,
                 (double) 2.2,
-                "1900-08-08",
+                Date.valueOf("1900-08-08"),
                 "1900-08-08 00:00:00",
                 Decimal.apply(8888L, 4, 2),
                 "char2"
@@ -289,7 +292,7 @@ public class TestRowBatch {
                 3L,
                 (float) 3.3,
                 (double) 3.3,
-                "2100-08-08",
+                Date.valueOf("2100-08-08"),
                 "2100-08-08 00:00:00",
                 Decimal.apply(10L, 2, 0),
                 "char3"
@@ -297,15 +300,15 @@ public class TestRowBatch {
 
         Assert.assertTrue(rowBatch.hasNext());
         List<Object> actualRow1 = rowBatch.next();
-        Assert.assertEquals(expectedRow1, actualRow1);
+        Assert.assertArrayEquals(expectedRow1.toArray(), actualRow1.toArray());
 
         Assert.assertTrue(rowBatch.hasNext());
         List<Object> actualRow2 = rowBatch.next();
-        Assert.assertEquals(expectedRow2, actualRow2);
+        Assert.assertArrayEquals(expectedRow2.toArray(), actualRow2.toArray());
 
         Assert.assertTrue(rowBatch.hasNext());
         List<Object> actualRow3 = rowBatch.next();
-        Assert.assertEquals(expectedRow3, actualRow3);
+        Assert.assertArrayEquals(expectedRow3.toArray(), actualRow3.toArray());
 
         Assert.assertFalse(rowBatch.hasNext());
         thrown.expect(NoSuchElementException.class);
@@ -511,8 +514,8 @@ public class TestRowBatch {
 
         Assert.assertTrue(rowBatch.hasNext());
         List<Object> actualRow0 = rowBatch.next();
-        Assert.assertEquals(LocalDate.parse("2023-08-09"), actualRow0.get(0));
-        Assert.assertEquals(LocalDate.parse("2023-08-10"), actualRow0.get(1));
+        Assert.assertEquals(Date.valueOf("2023-08-09"), actualRow0.get(0));
+        Assert.assertEquals(Date.valueOf("2023-08-10"), actualRow0.get(1));
 
         Assert.assertFalse(rowBatch.hasNext());
         thrown.expect(NoSuchElementException.class);
@@ -574,7 +577,6 @@ public class TestRowBatch {
         scanBatchResult.setEos(false);
         scanBatchResult.setRows(outputStream.toByteArray());
 
-
         String schemaStr = "{\"properties\":[" +
                 "{\"type\":\"LARGEINT\",\"name\":\"k1\",\"comment\":\"\"}, " +
                 "{\"type\":\"LARGEINT\",\"name\":\"k2\",\"comment\":\"\"}" +
@@ -586,8 +588,9 @@ public class TestRowBatch {
 
         Assert.assertTrue(rowBatch.hasNext());
         List<Object> actualRow0 = rowBatch.next();
-        Assert.assertEquals(new BigInteger("9223372036854775808"), actualRow0.get(0));
-        Assert.assertEquals(new BigInteger("9223372036854775809"), actualRow0.get(1));
+
+        Assert.assertEquals(Decimal.apply(new BigInteger("9223372036854775808")), actualRow0.get(0));
+        Assert.assertEquals(Decimal.apply(new BigInteger("9223372036854775809")), actualRow0.get(1));
 
         Assert.assertFalse(rowBatch.hasNext());
         thrown.expect(NoSuchElementException.class);

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/serialization/TestRowBatch.java
@@ -17,23 +17,14 @@
 
 package org.apache.doris.spark.serialization;
 
-import static org.hamcrest.core.StringStartsWith.startsWith;
+import org.apache.doris.sdk.thrift.TScanBatchResult;
+import org.apache.doris.sdk.thrift.TStatus;
+import org.apache.doris.sdk.thrift.TStatusCode;
+import org.apache.doris.spark.exception.DorisException;
+import org.apache.doris.spark.rest.RestService;
+import org.apache.doris.spark.rest.models.Schema;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.text.DateFormat;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.NoSuchElementException;
-
+import com.google.common.collect.ImmutableList;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -54,13 +45,6 @@ import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.doris.sdk.thrift.TScanBatchResult;
-import org.apache.doris.sdk.thrift.TStatus;
-import org.apache.doris.sdk.thrift.TStatusCode;
-import org.apache.doris.spark.exception.DorisException;
-import org.apache.doris.spark.rest.RestService;
-import org.apache.doris.spark.rest.models.Schema;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.spark.sql.types.Decimal;
 import org.junit.Assert;
@@ -70,8 +54,16 @@ import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-import scala.math.BigInt;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.hamcrest.core.StringStartsWith.startsWith;
 
 public class TestRowBatch {
     private final static Logger logger = LoggerFactory.getLogger(TestRowBatch.class);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

- read largeint type as decimal(38,0)
- read date/datev2 type as java.sql.date

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
