### PR TITLE
[fix] not in clause is not converted correctly

### DIFF
--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisRelation.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisRelation.scala
@@ -17,18 +17,17 @@
 
 package org.apache.doris.spark.sql
 
-import scala.collection.JavaConverters._
-import scala.collection.mutable
-import scala.math.min
-
 import org.apache.doris.spark.cfg.ConfigurationOptions._
 import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.jdbc.JdbcDialects
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.math.min
 
 
 private[sql] class DorisRelation(
@@ -81,8 +80,7 @@ private[sql] class DorisRelation(
     }
 
     if (filters != null && filters.length > 0) {
-      val dorisFilterQuery = cfg.getProperty(ConfigurationOptions.DORIS_FILTER_QUERY, "1=1")
-      paramWithScan += (ConfigurationOptions.DORIS_FILTER_QUERY -> (dorisFilterQuery + " and " + filterWhereClause))
+      paramWithScan += (ConfigurationOptions.DORIS_FILTER_QUERY -> filterWhereClause)
     }
 
     new ScalaDorisRowRDD(sqlContext.sparkContext, paramWithScan.toMap, lazySchema)

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/Utils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/Utils.scala
@@ -59,6 +59,12 @@ private[spark] object Utils {
         } else {
           s"${quote(attribute)} in (${compileValue(values)})"
         }
+      case Not(In(attribute, values)) =>
+        if (values.isEmpty || values.length >= inValueLengthLimit) {
+          null
+        } else {
+          s"${quote(attribute)} not in (${compileValue(values)})"
+        }
       case IsNull(attribute) => s"${quote(attribute)} is null"
       case IsNotNull(attribute) => s"${quote(attribute)} is not null"
       case And(left, right) =>


### PR DESCRIPTION
## Problem Summary:

When reading doris with not in clause，this error ocurrs：
> Doris FE's response cannot map to schema. res: {"exception":"errCode = 2, detailMessage = Syntax error in line 1:
> select `id`,`k1` from `test`.`test2` where 1=1 and 
> Encountered: EOF
> Expected: IDENTIFIER
> ","status":400}
> com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "exception" (class > > > > 
> org.apache.doris.spark.rest.models.QueryPlan), not marked as ignorable (3 known properties: "partitions", "status", > 
> "opaqued_query_plan"])
> at [Source: (String)"{"exception":"errCode = 2, detailMessage = Syntax error in line 1:
> select `id`,`k1` from `test`.`test2` where 1=1 and \n                                                   ^
> Encountered: EOF
> Expected: IDENTIFIER
> ","status":400}"; line: 1, column: 15] (through reference chain: > > 
> org.apache.doris.spark.rest.models.QueryPlan["exception"])

# Proposed changes

1. fix not in clause compile
2. Disable `doris.filter.query` parameter when reading doris via DataFrame and SQL

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
