### PR TITLE
[fix] streaming write execution plan error

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -100,4 +100,10 @@ public interface ConfigurationOptions {
     String DORIS_SINK_ENABLE_2PC = "doris.sink.enable-2pc";
     boolean DORIS_SINK_ENABLE_2PC_DEFAULT = false;
 
+    /**
+     * pass through json data when sink to doris in streaming mode
+     */
+    String DORIS_SINK_STREAMING_PASSTHROUGH = "doris.sink.streaming.passthrough";
+    boolean DORIS_SINK_STREAMING_PASSTHROUGH_DEFAULT = false;
+
 }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -480,8 +480,11 @@ public class DorisStreamLoad implements Serializable {
 
     private void handleStreamPassThrough() {
 
-        LOG.info("handle stream pass through, force the format option to json");
-        streamLoadProp.put("format", "json");
+        if ("json".equalsIgnoreCase(fileType)) {
+            LOG.info("handle stream pass through, force set read_json_by_line is true for json format");
+            streamLoadProp.put("read_json_by_line", "true");
+            streamLoadProp.remove("strip_outer_array");
+        }
 
     }
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -96,6 +96,8 @@ public class DorisStreamLoad implements Serializable {
 
     private boolean readJsonByLine = false;
 
+    private boolean streamingPassthrough = false;
+
     public DorisStreamLoad(SparkSettings settings) {
         String[] dbTable = settings.getProperty(ConfigurationOptions.DORIS_TABLE_IDENTIFIER).split("\\.");
         this.db = dbTable[0];
@@ -121,6 +123,8 @@ public class DorisStreamLoad implements Serializable {
             }
         }
         LINE_DELIMITER = escapeString(streamLoadProp.getOrDefault("line_delimiter", "\n"));
+        this.streamingPassthrough = settings.getBooleanProperty(ConfigurationOptions.DORIS_SINK_STREAMING_PASSTHROUGH,
+                ConfigurationOptions.DORIS_SINK_STREAMING_PASSTHROUGH_DEFAULT);
     }
 
     public String getLoadUrlStr() {
@@ -176,6 +180,38 @@ public class DorisStreamLoad implements Serializable {
     public List<Integer> loadV2(List<List<Object>> rows, String[] dfColumns, Boolean enable2PC) throws StreamLoadException, JsonProcessingException {
 
         List<String> loadData = parseLoadData(rows, dfColumns);
+        List<Integer> txnIds = new ArrayList<>(loadData.size());
+
+        try {
+            for (String data : loadData) {
+                txnIds.add(load(data, enable2PC));
+            }
+        } catch (StreamLoadException e) {
+            if (enable2PC && !txnIds.isEmpty()) {
+                LOG.error("load batch failed, abort previously pre-committed transactions");
+                for (Integer txnId : txnIds) {
+                    abort(txnId);
+                }
+            }
+            throw e;
+        }
+
+        return txnIds;
+
+    }
+
+    public List<Integer> loadStream(List<List<Object>> rows, String[] dfColumns, Boolean enable2PC)
+            throws StreamLoadException, JsonProcessingException {
+
+        List<String> loadData;
+
+        if (this.streamingPassthrough) {
+            handleStreamPassThrough();
+            loadData = passthrough(rows);
+        } else {
+            loadData = parseLoadData(rows, dfColumns);
+        }
+
         List<Integer> txnIds = new ArrayList<>(loadData.size());
 
         try {
@@ -440,6 +476,17 @@ public class DorisStreamLoad implements Serializable {
             }
         }
         return hexData;
+    }
+
+    private void handleStreamPassThrough() {
+
+        LOG.info("handle stream pass through, force the format option to json");
+        streamLoadProp.put("format", "json");
+
+    }
+
+    private List<String> passthrough(List<List<Object>> values) {
+        return values.stream().map(list -> list.get(0).toString()).collect(Collectors.toList());
     }
 
 }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisStreamLoadSink.scala
@@ -34,7 +34,7 @@ private[sql] class DorisStreamLoadSink(sqlContext: SQLContext, settings: SparkSe
     if (batchId <= latestBatchId) {
       logger.info(s"Skipping already committed batch $batchId")
     } else {
-      writer.write(data)
+      writer.writeStream(data)
       latestBatchId = batchId
     }
   }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
@@ -22,6 +22,9 @@ import org.apache.doris.spark.listener.DorisTransactionListener
 import org.apache.doris.spark.load.{CachedDorisStreamLoadClient, DorisStreamLoad}
 import org.apache.doris.spark.sql.Utils
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.CollectionAccumulator
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.IOException
@@ -76,33 +79,89 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
      * flush data to Doris and do retry when flush error
      *
      */
-    def flush(batch: Iterable[util.List[Object]], dfColumns: Array[String]): Unit = {
+    def flush(batch: Seq[util.List[Object]], dfColumns: Array[String]): Unit = {
       Utils.retry[util.List[Integer], Exception](maxRetryTimes, Duration.ofMillis(batchInterValMs.toLong), logger) {
-        dorisStreamLoader.loadV2(batch.toList.asJava, dfColumns, enable2PC)
+        dorisStreamLoader.loadV2(batch.asJava, dfColumns, enable2PC)
       } match {
-        case Success(txnIds) => if (enable2PC) txnIds.asScala.foreach(txnId => preCommittedTxnAcc.add(txnId))
+        case Success(txnIds) => if (enable2PC) handleLoadSuccess(txnIds.asScala, preCommittedTxnAcc)
         case Failure(e) =>
-          if (enable2PC) {
-            // if task run failed, acc value will not be returned to driver,
-            // should abort all pre committed transactions inside the task
-            logger.info("load task failed, start aborting previously pre-committed transactions")
-            val abortFailedTxnIds = mutable.Buffer[Int]()
-            preCommittedTxnAcc.value.asScala.foreach(txnId => {
-              Utils.retry[Unit, Exception](3, Duration.ofSeconds(1), logger) {
-                dorisStreamLoader.abort(txnId)
-              } match {
-                case Success(_) =>
-                case Failure(_) => abortFailedTxnIds += txnId
-              }
-            })
-            if (abortFailedTxnIds.nonEmpty) logger.warn("not aborted txn ids: {}", abortFailedTxnIds.mkString(","))
-            preCommittedTxnAcc.reset()
-          }
+          if (enable2PC) handleLoadFailure(preCommittedTxnAcc)
           throw new IOException(
             s"Failed to load batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", e)
       }
     }
 
+  }
+
+  def writeStream(dataFrame: DataFrame): Unit = {
+
+    val sc = dataFrame.sqlContext.sparkContext
+    val preCommittedTxnAcc = sc.collectionAccumulator[Int]("preCommittedTxnAcc")
+    if (enable2PC) {
+      sc.addSparkListener(new DorisTransactionListener(preCommittedTxnAcc, dorisStreamLoader))
+    }
+
+    var resultRdd = dataFrame.queryExecution.toRdd
+    val schema = dataFrame.schema
+    val dfColumns = dataFrame.columns
+    if (Objects.nonNull(sinkTaskPartitionSize)) {
+      resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
+    }
+    resultRdd
+      .foreachPartition(partition => {
+        partition
+          .grouped(batchSize)
+          .foreach(batch =>
+            flush(batch, dfColumns))
+      })
+
+    /**
+     * flush data to Doris and do retry when flush error
+     *
+     */
+    def flush(batch: Seq[InternalRow], dfColumns: Array[String]): Unit = {
+      Utils.retry[util.List[Integer], Exception](maxRetryTimes, Duration.ofMillis(batchInterValMs.toLong), logger) {
+        dorisStreamLoader.loadStream(convertToObjectList(batch, schema), dfColumns, enable2PC)
+      } match {
+        case Success(txnIds) => if (enable2PC) handleLoadSuccess(txnIds.asScala, preCommittedTxnAcc)
+        case Failure(e) =>
+          if (enable2PC) handleLoadFailure(preCommittedTxnAcc)
+          throw new IOException(
+            s"Failed to load batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node and exceeded the max ${maxRetryTimes} retry times.", e)
+      }
+    }
+
+    def convertToObjectList(rows: Seq[InternalRow], schema: StructType): util.List[util.List[Object]] = {
+      rows.map(row => {
+        row.toSeq(schema).map(_.asInstanceOf[AnyRef]).toList.asJava
+      }).asJava
+    }
+
+  }
+
+  private def handleLoadSuccess(txnIds: mutable.Buffer[Integer], acc: CollectionAccumulator[Int]): Unit = {
+    txnIds.foreach(txnId => acc.add(txnId))
+  }
+
+  def handleLoadFailure(acc: CollectionAccumulator[Int]): Unit = {
+    // if task run failed, acc value will not be returned to driver,
+    // should abort all pre committed transactions inside the task
+    logger.info("load task failed, start aborting previously pre-committed transactions")
+    if (acc.isZero) {
+      logger.info("no pre-committed transactions, skip abort")
+      return
+    }
+    val abortFailedTxnIds = mutable.Buffer[Int]()
+    acc.value.asScala.foreach(txnId => {
+      Utils.retry[Unit, Exception](3, Duration.ofSeconds(1), logger) {
+        dorisStreamLoader.abort(txnId)
+      } match {
+        case Success(_) =>
+        case Failure(_) => abortFailedTxnIds += txnId
+      }
+    })
+    if (abortFailedTxnIds.nonEmpty) logger.warn("not aborted txn ids: {}", abortFailedTxnIds.mkString(","))
+    acc.reset()
   }
 
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When writing doris through structured streaming, the following exception will occur:

```java
23/09/01 14:13:40 ERROR MicroBatchExecution: Query [id = c1d9450a-43ab-46fd-9826-10e0eb8ab1bc, runId = 21bd5cfe-84a1-487f-a2e7-ce27e2813691] terminated with error
org.apache.spark.sql.AnalysisException: Queries with streaming sources must be executed with writeStream.start();
StreamingDataSourceV2Relation [key#7, value#8, topic#9, partition#10, offset#11L, timestamp#12, timestampType#13], org.apache.spark.sql.kafka010.KafkaSourceProvider$KafkaScan@56bd0218, KafkaV2[Subscribe[spark_streaming_test]], {"spark_streaming_test":{"0":13}}, {"spark_streaming_test":{"0":14}}

	at org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker$.throwError(UnsupportedOperationChecker.scala:421)
	at org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker$.$anonfun$checkForBatch$1(UnsupportedOperationChecker.scala:38)
	at org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker$.$anonfun$checkForBatch$1$adapted(UnsupportedOperationChecker.scala:36)
	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:184)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(TreeNode.scala:183)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(TreeNode.scala:183)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:183)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(TreeNode.scala:183)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(TreeNode.scala:183)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:183)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(TreeNode.scala:183)
	at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(TreeNode.scala:183)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(TreeNode.scala:183)
	at org.apache.spark.sql.catalyst.analysis.UnsupportedOperationChecker$.checkForBatch(UnsupportedOperationChecker.scala:36)
	at org.apache.spark.sql.execution.QueryExecution.assertSupported(QueryExecution.scala:67)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$withCachedData$1(QueryExecution.scala:78)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
	at org.apache.spark.sql.execution.QueryExecution.withCachedData$lzycompute(QueryExecution.scala:76)
	at org.apache.spark.sql.execution.QueryExecution.withCachedData(QueryExecution.scala:76)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$optimizedPlan$1(QueryExecution.scala:87)
	at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
	at org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(QueryExecution.scala:143)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
	at org.apache.spark.sql.execution.QueryExecution.executePhase(QueryExecution.scala:143)
	at org.apache.spark.sql.execution.QueryExecution.optimizedPlan$lzycompute(QueryExecution.scala:84)
	at org.apache.spark.sql.execution.QueryExecution.optimizedPlan(QueryExecution.scala:84)
	at org.apache.spark.sql.execution.QueryExecution.assertOptimized(QueryExecution.scala:95)
	at org.apache.spark.sql.execution.QueryExecution.executedPlan$lzycompute(QueryExecution.scala:113)
	at org.apache.spark.sql.execution.QueryExecution.executedPlan(QueryExecution.scala:110)
	at org.apache.spark.sql.execution.QueryExecution.toRdd$lzycompute(QueryExecution.scala:132)
	at org.apache.spark.sql.execution.QueryExecution.toRdd(QueryExecution.scala:131)
	at org.apache.spark.sql.Dataset.rdd$lzycompute(Dataset.scala:3241)
	at org.apache.spark.sql.Dataset.rdd(Dataset.scala:3239)
	at org.apache.doris.spark.writer.DorisWriter.write(DorisWriter.scala:62)
	at org.apache.doris.spark.sql.DorisStreamLoadSink.addBatch(DorisStreamLoadSink.scala:37)
	at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runBatch$16(MicroBatchExecution.scala:586)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$5(SQLExecution.scala:103)
	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:163)
	at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:90)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:64)
	at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runBatch$15(MicroBatchExecution.scala:584)
	at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:357)
	at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:355)
	at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:68)
	at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runBatch(MicroBatchExecution.scala:584)
	at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$2(MicroBatchExecution.scala:226)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:357)
	at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:355)
	at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:68)
	at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$1(MicroBatchExecution.scala:194)
	at org.apache.spark.sql.execution.streaming.ProcessingTimeExecutor.execute(TriggerExecutor.scala:57)
	at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runActivatedStream(MicroBatchExecution.scala:188)
	at org.apache.spark.sql.execution.streaming.StreamExecution.$anonfun$runStream$1(StreamExecution.scala:334)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:775)
	at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:317)
	at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:244)
```

When processing micro-batch data in sink, call `dataframe.rdd` to convert dataframe to `RDD` to process data. In this way, `Spark` will start the job in batch mode, causing the streaming job failure.

The correct way is to get RDD by calling `dataframe.queryExecution.toRdd`, which will trigger the query plan on each micro-batch to convert the source data into the final result `RDD`.

And also, a new configuration option has been added, `doris.sink.streaming.passthrough`.
This is a `boolean` type option, default value is `false`. By setting this option to `true`, the value of the first column is directly written to doris through stream load without processing.

This method supports writing in both `csv` and `json` formats, but the `json` format only supports `read_json_by_line` mode.

Example:

- If you need to write a dataframe of structured data, the configuration method is the same as the batch mode.

```scala

val sourceDf = spark.readStream.
       .format("your_own_stream_source")
       .load()

val resultDf = sourceDf.<transformations>

resultDf.writeStream
      .format("doris")
      .option("checkpointLocation", "/checkpoint")
      .option("doris.table.identifier", "db.table")
      .option("doris.fenodes", "127.0.0.1:8030")
      .option("user", "root")
      .option("password", "")
      .start()
      .awaitTermination()

```

- If you consume messages from kafka, and the message format happens to be a `csv` or `json` string that conforms to the stream load specification, you can set `doris.sink.streaming.passthrough` to `true` to write the message data directly.

```scala

val sourceDf = spark.readStream.
       .format("your_own_stream_source")
       .load()

// Extract value from kafka record data
val resultDf = sourceDf.selectExpr("CAST(value AS STRING) AS value")

resultDf.writeStream
      .format("doris")
      .option("checkpointLocation", "/checkpoint")
      .option("doris.table.identifier", "db.table")
      .option("doris.fenodes", "127.0.0.1:8030")
      .option("user", "root")
      .option("password", "")
      .option("doris.sink.streaming.passthrough", "true")
      .option("doris.sink.properties.format", "json")
      .option("doris.sink.properties.read_json_by_line", "true")
      .start()
      .awaitTermination()

```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
