### PR TITLE
[improvement] 2pc txn commit or abort retry and interval configurable.

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -106,4 +106,16 @@ public interface ConfigurationOptions {
     String DORIS_SINK_STREAMING_PASSTHROUGH = "doris.sink.streaming.passthrough";
     boolean DORIS_SINK_STREAMING_PASSTHROUGH_DEFAULT = false;
 
+    /**
+     * txnId commit or abort interval
+     */
+    String DORIS_SINK_TXN_INTERVAL_MS = "doris.sink.txn.interval.ms";
+    int DORIS_SINK_TXN_INTERVAL_MS_DEFAULT = 50;
+
+    /**
+     * txnId commit or abort retry times
+     */
+    String DORIS_SINK_TXN_RETRIES = "doris.sink.txn.retries";
+    int DORIS_SINK_TXN_RETRIES_DEFAULT = 3;
+
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

2pc txn commit or abort retry and interval configurable. Prevent 2pc txn submission  too slow

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
