### PR TITLE
[bug] byteBuffer calculate new capacity bug fix.

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatchInputStream.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatchInputStream.java
@@ -170,14 +170,13 @@ public class RecordBatchInputStream extends InputStream {
      * @return new capacity
      */
     private int calculateNewCapacity(int capacity, int minCapacity) {
-        int newCapacity;
+        int newCapacity = 0;
         if (capacity == 0) {
             newCapacity = DEFAULT_BUF_SIZE;
-            while (newCapacity < minCapacity) {
-                newCapacity = newCapacity << 1;
-            }
-        } else {
-            newCapacity = capacity << 1;
+
+        }
+        while (newCapacity < minCapacity) {
+            newCapacity = newCapacity << 1;
         }
         return newCapacity;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

byteBuffer calculate new capacity bug fix.
![image](https://github.com/apache/doris-spark-connector/assets/64473732/030b7102-7b8a-485c-bb46-7c94bec12e39)


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
