### PR TITLE
[improve] Reduce the performance loss of additional buffer expansion.

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatchInputStream.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatchInputStream.java
@@ -40,8 +40,6 @@ public class RecordBatchInputStream extends InputStream {
 
     public static final Logger LOG = LoggerFactory.getLogger(RecordBatchInputStream.class);
 
-    private static final int DEFAULT_BUF_SIZE = 4096;
-
     /**
      * Load record batch
      */
@@ -55,7 +53,12 @@ public class RecordBatchInputStream extends InputStream {
     /**
      * record buffer
      */
-    private ByteBuffer buffer = ByteBuffer.allocate(0);
+
+    private ByteBuffer lineBuf = ByteBuffer.allocate(0);;
+
+    private ByteBuffer delimBuf = ByteBuffer.allocate(0);
+
+    private final byte[] delim;
 
     /**
      * record count has been read
@@ -70,31 +73,42 @@ public class RecordBatchInputStream extends InputStream {
     public RecordBatchInputStream(RecordBatch recordBatch, boolean passThrough) {
         this.recordBatch = recordBatch;
         this.passThrough = passThrough;
+        this.delim = recordBatch.getDelim();
     }
 
     @Override
     public int read() throws IOException {
         try {
-            if (buffer.remaining() == 0 && endOfBatch()) {
-                return -1; // End of stream
+            if (lineBuf.remaining() == 0 && endOfBatch()) {
+                return -1;
+            }
+
+            if (delimBuf != null && delimBuf.remaining() > 0) {
+                return delimBuf.get() & 0xff;
             }
         } catch (DorisException e) {
             throw new IOException(e);
         }
-        return buffer.get() & 0xFF;
+        return lineBuf.get() & 0xFF;
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         try {
-            if (buffer.remaining() == 0 && endOfBatch()) {
-                return -1; // End of stream
+            if (lineBuf.remaining() == 0 && endOfBatch()) {
+                return -1;
+            }
+
+            if (delimBuf != null && delimBuf.remaining() > 0) {
+                int bytesRead = Math.min(len, delimBuf.remaining());
+                delimBuf.get(b, off, bytesRead);
+                return bytesRead;
             }
         } catch (DorisException e) {
             throw new IOException(e);
         }
-        int bytesRead = Math.min(len, buffer.remaining());
-        buffer.get(b, off, bytesRead);
+        int bytesRead = Math.min(len, lineBuf.remaining());
+        lineBuf.get(b, off, bytesRead);
         return bytesRead;
     }
 
@@ -109,6 +123,7 @@ public class RecordBatchInputStream extends InputStream {
     public boolean endOfBatch() throws DorisException {
         Iterator<InternalRow> iterator = recordBatch.getIterator();
         if (readCount >= recordBatch.getBatchSize() || !iterator.hasNext()) {
+            delimBuf = null;
             return true;
         }
         readNext(iterator);
@@ -125,60 +140,16 @@ public class RecordBatchInputStream extends InputStream {
         if (!iterator.hasNext()) {
             throw new ShouldNeverHappenException();
         }
-        byte[] delim = recordBatch.getDelim();
         byte[] rowBytes = rowToByte(iterator.next());
         if (isFirst) {
-            ensureCapacity(rowBytes.length);
-            buffer.put(rowBytes);
-            buffer.flip();
+            delimBuf = null;
+            lineBuf = ByteBuffer.wrap(rowBytes);
             isFirst = false;
         } else {
-            ensureCapacity(delim.length + rowBytes.length);
-            buffer.put(delim);
-            buffer.put(rowBytes);
-            buffer.flip();
+            delimBuf =  ByteBuffer.wrap(delim);
+            lineBuf = ByteBuffer.wrap(rowBytes);
         }
         readCount++;
-    }
-
-    /**
-     * Check if the buffer has enough capacity.
-     *
-     * @param need required buffer space
-     */
-    private void ensureCapacity(int need) {
-
-        int capacity = buffer.capacity();
-
-        if (need <= capacity) {
-            buffer.clear();
-            return;
-        }
-
-        // need to extend
-        int newCapacity = calculateNewCapacity(capacity, need);
-        LOG.info("expand buffer, min cap: {}, now cap: {}, new cap: {}", need, capacity, newCapacity);
-        buffer = ByteBuffer.allocate(newCapacity);
-
-    }
-
-    /**
-     * Calculate new capacity for buffer expansion.
-     *
-     * @param capacity current buffer capacity
-     * @param minCapacity required min buffer space
-     * @return new capacity
-     */
-    private int calculateNewCapacity(int capacity, int minCapacity) {
-        int newCapacity = 0;
-        if (capacity == 0) {
-            newCapacity = DEFAULT_BUF_SIZE;
-
-        }
-        while (newCapacity < minCapacity) {
-            newCapacity = newCapacity << 1;
-        }
-        return newCapacity;
     }
 
     /**
@@ -219,6 +190,5 @@ public class RecordBatchInputStream extends InputStream {
         return bytes;
 
     }
-
 
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

Currently, the implementation of RecordBatchInputStream.readNext requires the introduction of additional ByteBuffer and continuous resizing, which leads to significant performance overhead. Furthermore, the current ByteBuffer resizing logic can result in overflow and enter into an infinite loop.

Therefore, it is possible to optimize and reduce the introduction of additional ByteBuffers while minimizing the performance impact caused by resizing.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
