### PR TITLE
[fix] Fix data loss due to internal retries

### DIFF
--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
@@ -67,7 +67,7 @@ class DorisTransactionListener(preCommittedTxnAcc: CollectionAccumulator[Int], d
         logger.info("job run failed, start aborting transactions")
         txnIds.foreach(txnId =>
           Utils.retry(sinkTxnRetries, Duration.ofMillis(sinkTnxIntervalMs), logger) {
-            dorisStreamLoad.abort(txnId)
+            dorisStreamLoad.abortById(txnId)
           } match {
             case Success(_) =>
             case Failure(_) => failedTxnIds += txnId


### PR DESCRIPTION
# Proposed changes

## Problem Summary:

After write optimization, the upstream data is read through the iterator. Since the iterator can only traverse in one direction, the current batch cannot be reread during the internal retry.

So the solution is to remove the internal retry, and the failure exception when executing the load will be thrown.
If the `spark.task.maxFailures` parameter is set (default value is 4), or other retry-related parameters, the Spark scheduler will retry the task.

Other changes:
1. abort transaction by label when current load is failed
2. do some style changes

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
