### PR TITLE
[improvement] batch load retry

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -70,7 +70,7 @@ public interface ConfigurationOptions {
     int SINK_BATCH_SIZE_DEFAULT = 100000;
 
     String DORIS_SINK_MAX_RETRIES = "doris.sink.max-retries";
-    int SINK_MAX_RETRIES_DEFAULT = 1;
+    int SINK_MAX_RETRIES_DEFAULT = 0;
 
     String DORIS_MAX_FILTER_RATIO = "doris.max.filter.ratio";
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -98,7 +98,6 @@ public class DorisStreamLoad implements Serializable {
     private String FIELD_DELIMITER;
     private final String LINE_DELIMITER;
     private boolean streamingPassthrough = false;
-    private final Integer batchSize;
     private final boolean enable2PC;
     private final Integer txnRetries;
     private final Integer txnIntervalMs;
@@ -128,8 +127,6 @@ public class DorisStreamLoad implements Serializable {
         LINE_DELIMITER = escapeString(streamLoadProp.getOrDefault("line_delimiter", "\n"));
         this.streamingPassthrough = settings.getBooleanProperty(ConfigurationOptions.DORIS_SINK_STREAMING_PASSTHROUGH,
                 ConfigurationOptions.DORIS_SINK_STREAMING_PASSTHROUGH_DEFAULT);
-        this.batchSize = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_SIZE,
-                ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT);
         this.enable2PC = settings.getBooleanProperty(ConfigurationOptions.DORIS_SINK_ENABLE_2PC,
                 ConfigurationOptions.DORIS_SINK_ENABLE_2PC_DEFAULT);
         this.txnRetries = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_TXN_RETRIES,
@@ -200,7 +197,6 @@ public class DorisStreamLoad implements Serializable {
             this.loadUrlStr = loadUrlStr;
             HttpPut httpPut = getHttpPut(label, loadUrlStr, enable2PC);
             RecordBatchInputStream recodeBatchInputStream = new RecordBatchInputStream(RecordBatch.newBuilder(rows)
-                    .batchSize(batchSize)
                     .format(fileType)
                     .sep(FIELD_DELIMITER)
                     .delim(LINE_DELIMITER)

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatch.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatch.java
@@ -37,11 +37,6 @@ public class RecordBatch {
     private final Iterator<InternalRow> iterator;
 
     /**
-     * batch size for single load
-     */
-    private final int batchSize;
-
-    /**
      * stream load format
      */
     private final String format;
@@ -63,10 +58,9 @@ public class RecordBatch {
 
     private final boolean addDoubleQuotes;
 
-    private RecordBatch(Iterator<InternalRow> iterator, int batchSize, String format, String sep, byte[] delim,
+    private RecordBatch(Iterator<InternalRow> iterator, String format, String sep, byte[] delim,
                         StructType schema, boolean addDoubleQuotes) {
         this.iterator = iterator;
-        this.batchSize = batchSize;
         this.format = format;
         this.sep = sep;
         this.delim = delim;
@@ -76,10 +70,6 @@ public class RecordBatch {
 
     public Iterator<InternalRow> getIterator() {
         return iterator;
-    }
-
-    public int getBatchSize() {
-        return batchSize;
     }
 
     public String getFormat() {
@@ -112,8 +102,6 @@ public class RecordBatch {
 
         private final Iterator<InternalRow> iterator;
 
-        private int batchSize;
-
         private String format;
 
         private String sep;
@@ -126,11 +114,6 @@ public class RecordBatch {
 
         public Builder(Iterator<InternalRow> iterator) {
             this.iterator = iterator;
-        }
-
-        public Builder batchSize(int batchSize) {
-            this.batchSize = batchSize;
-            return this;
         }
 
         public Builder format(String format) {
@@ -159,7 +142,7 @@ public class RecordBatch {
         }
 
         public RecordBatch build() {
-            return new RecordBatch(iterator, batchSize, format, sep, delim, schema, addDoubleQuotes);
+            return new RecordBatch(iterator, format, sep, delim, schema, addDoubleQuotes);
         }
 
     }

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatchInputStream.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/RecordBatchInputStream.java
@@ -61,11 +61,6 @@ public class RecordBatchInputStream extends InputStream {
     private final byte[] delim;
 
     /**
-     * record count has been read
-     */
-    private int readCount = 0;
-
-    /**
      * streaming mode pass through data without process
      */
     private final boolean passThrough;
@@ -122,12 +117,12 @@ public class RecordBatchInputStream extends InputStream {
      */
     public boolean endOfBatch() throws DorisException {
         Iterator<InternalRow> iterator = recordBatch.getIterator();
-        if (readCount >= recordBatch.getBatchSize() || !iterator.hasNext()) {
-            delimBuf = null;
-            return true;
+        if (iterator.hasNext()) {
+            readNext(iterator);
+            return false;
         }
-        readNext(iterator);
-        return false;
+        delimBuf = null;
+        return true;
     }
 
     /**
@@ -149,7 +144,6 @@ public class RecordBatchInputStream extends InputStream {
             delimBuf =  ByteBuffer.wrap(delim);
             lineBuf = ByteBuffer.wrap(rowBytes);
         }
-        readCount++;
     }
 
     /**

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/listener/DorisTransactionListener.scala
@@ -47,8 +47,8 @@ class DorisTransactionListener(preCommittedTxnAcc: CollectionAccumulator[Int], d
         txnIds.foreach(txnId =>
           Utils.retry(sinkTxnRetries, Duration.ofMillis(sinkTnxIntervalMs), logger) {
             dorisStreamLoad.commit(txnId)
-          } match {
-            case Success(_) =>
+          } () match {
+            case Success(_) => // do nothing
             case Failure(_) => failedTxnIds += txnId
           }
         )
@@ -68,8 +68,8 @@ class DorisTransactionListener(preCommittedTxnAcc: CollectionAccumulator[Int], d
         txnIds.foreach(txnId =>
           Utils.retry(sinkTxnRetries, Duration.ofMillis(sinkTnxIntervalMs), logger) {
             dorisStreamLoad.abortById(txnId)
-          } match {
-            case Success(_) =>
+          } () match {
+            case Success(_) => // do nothing
             case Failure(_) => failedTxnIds += txnId
           })
         if (failedTxnIds.nonEmpty) {

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
@@ -21,7 +21,6 @@ import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}
 import org.apache.doris.spark.listener.DorisTransactionListener
 import org.apache.doris.spark.load.{CachedDorisStreamLoadClient, DorisStreamLoad}
 import org.apache.doris.spark.sql.Utils
-import org.apache.spark.TaskContext
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.types.StructType
@@ -32,10 +31,10 @@ import java.io.IOException
 import java.time.Duration
 import java.util
 import java.util.Objects
-import java.util.concurrent.locks.LockSupport
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
+import scala.collection.mutable.ArrayBuffer
+import scala.util.{Failure, Success}
 
 class DorisWriter(settings: SparkSettings) extends Serializable {
 
@@ -44,8 +43,17 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
   private val sinkTaskPartitionSize: Integer = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_TASK_PARTITION_SIZE)
   private val sinkTaskUseRepartition: Boolean = settings.getProperty(ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION,
     ConfigurationOptions.DORIS_SINK_TASK_USE_REPARTITION_DEFAULT.toString).toBoolean
+
+  private val maxRetryTimes: Int = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_MAX_RETRIES,
+    ConfigurationOptions.SINK_MAX_RETRIES_DEFAULT)
+  private val batchSize: Integer = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_SIZE,
+    ConfigurationOptions.SINK_BATCH_SIZE_DEFAULT)
   private val batchInterValMs: Integer = settings.getIntegerProperty(ConfigurationOptions.DORIS_SINK_BATCH_INTERVAL_MS,
     ConfigurationOptions.DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT)
+
+  if (maxRetryTimes > 0) {
+    logger.info(s"batch retry enabled, size is $batchSize, interval is $batchInterValMs")
+  }
 
   private val enable2PC: Boolean = settings.getBooleanProperty(ConfigurationOptions.DORIS_SINK_ENABLE_2PC,
     ConfigurationOptions.DORIS_SINK_ENABLE_2PC_DEFAULT)
@@ -77,7 +85,6 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
   private def doWrite(dataFrame: DataFrame, loadFunc: (util.Iterator[InternalRow], StructType) => Int): Unit = {
 
     val sc = dataFrame.sqlContext.sparkContext
-    logger.info(s"applicationAttemptId: ${sc.applicationAttemptId.getOrElse(-1)}")
     val preCommittedTxnAcc = sc.collectionAccumulator[Int]("preCommittedTxnAcc")
     if (enable2PC) {
       sc.addSparkListener(new DorisTransactionListener(preCommittedTxnAcc, dorisStreamLoader, sinkTxnIntervalMs, sinkTxnRetries))
@@ -89,19 +96,22 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
       resultRdd = if (sinkTaskUseRepartition) resultRdd.repartition(sinkTaskPartitionSize) else resultRdd.coalesce(sinkTaskPartitionSize)
     }
     resultRdd.foreachPartition(iterator => {
-      val intervalNanos = Duration.ofMillis(batchInterValMs.toLong).toNanos
+
       while (iterator.hasNext) {
-        Try {
-          loadFunc(iterator.asJava, schema)
-        } match {
-          case Success(txnId) => if (enable2PC) handleLoadSuccess(txnId, preCommittedTxnAcc)
+        val batchIterator = new BatchIterator[InternalRow](iterator, batchSize, maxRetryTimes > 0)
+        val retry = Utils.retry[Int, Exception](maxRetryTimes, Duration.ofMillis(batchInterValMs.toLong), logger) _
+        retry(loadFunc(batchIterator.asJava, schema))(batchIterator.reset()) match {
+          case Success(txnId) =>
+            if (enable2PC) handleLoadSuccess(txnId, preCommittedTxnAcc)
+            batchIterator.close()
           case Failure(e) =>
             if (enable2PC) handleLoadFailure(preCommittedTxnAcc)
+            batchIterator.close()
             throw new IOException(
               s"Failed to load batch data on BE: ${dorisStreamLoader.getLoadUrlStr} node.", e)
         }
-        LockSupport.parkNanos(intervalNanos)
       }
+
     })
 
   }
@@ -120,15 +130,70 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
     }
     val abortFailedTxnIds = mutable.Buffer[Int]()
     acc.value.asScala.foreach(txnId => {
-      Utils.retry[Unit, Exception](sinkTxnRetries, Duration.ofMillis(sinkTxnIntervalMs), logger) {
+      Utils.retry[Unit, Exception](3, Duration.ofSeconds(1), logger) {
         dorisStreamLoader.abortById(txnId)
-      } match {
-        case Success(_) =>
+      }() match {
+        case Success(_) => // do nothing
         case Failure(_) => abortFailedTxnIds += txnId
       }
     })
     if (abortFailedTxnIds.nonEmpty) logger.warn("not aborted txn ids: {}", abortFailedTxnIds.mkString(","))
     acc.reset()
+  }
+
+  /**
+   * iterator for batch load
+   * if retry time is greater than zero, enable batch retry and put batch data into buffer
+   *
+   * @param iterator         parent iterator
+   * @param batchSize        batch size
+   * @param batchRetryEnable whether enable batch retry
+   * @tparam T data type
+   */
+  private class BatchIterator[T](iterator: Iterator[T], batchSize: Int, batchRetryEnable: Boolean) extends Iterator[T] {
+
+    private val buffer: ArrayBuffer[T] = if (batchRetryEnable) new ArrayBuffer[T](batchSize) else ArrayBuffer.empty[T]
+
+    private var recordCount = 0
+
+    private var isReset = false
+
+    override def hasNext: Boolean = recordCount < batchSize && iterator.hasNext
+
+    override def next(): T = {
+      recordCount += 1
+      if (batchRetryEnable) {
+        if (isReset && buffer.nonEmpty) {
+          buffer(recordCount)
+        } else {
+          val elem = iterator.next
+          buffer += elem
+          elem
+        }
+      } else {
+        iterator.next
+      }
+    }
+
+    /**
+     * reset record count for re-read
+     */
+    def reset(): Unit = {
+      recordCount = 0
+      isReset = true
+      logger.info("batch iterator is reset")
+    }
+
+    /**
+     * clear buffer when buffer is not empty
+     */
+    def close(): Unit = {
+      if (buffer.nonEmpty) {
+        buffer.clear()
+        logger.info("buffer is cleared and batch iterator is closed")
+      }
+    }
+
   }
 
 


### PR DESCRIPTION
# Problem Summary

In the current implementation, due to traversing data through iterators and sending data in a stream, batch loading does not implement batch retry. Task retry will be performed after the load request fails, and the cost of task retry is relatively high. For some scenarios such as network jitter, batch retry is a better way

## Proposed changes:

The implementation of this PR is to choose whether to retry batch loading when it fails through configuration.
The behavior is as follows：
Batch retry is enabled when sink.max-retries is set greater than 0，an iterator is implemented to cache batch data, and a count value is used to control batch writing. 
When the batch fails, reset the count and set the flag bit, and re-read the current batch data from the cache array.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
