### PR TITLE
[Enhancemant](HLL) support export doris hll/bitmap data type

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
@@ -377,6 +377,16 @@ public class RowBatch {
                             addValueToRow(rowIndex, value);
                         }
                         break;
+                    case "HLL":
+                    case "BITMAP":
+                        Preconditions.checkArgument(mt.equals(Types.MinorType.VARCHAR),
+                                typeMismatchMessage(currentType, mt));
+                        VarCharVector varcharVector = (VarCharVector) curFieldVector;
+                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
+                            Object fieldValue = varcharVector.isNull(rowIndex) ? null : varcharVector.get(rowIndex);
+                            addValueToRow(rowIndex, fieldValue);
+                        }
+                        break;
                     default:
                         String errMsg = "Unsupported type " + schema.get(col).getType();
                         logger.error(errMsg);

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
@@ -130,8 +130,8 @@ private[spark] object SchemaUtils {
       case "ARRAY"           => DataTypes.StringType
       case "MAP"             => MapType(DataTypes.StringType, DataTypes.StringType)
       case "STRUCT"          => DataTypes.StringType
-      case "HLL"             =>
-        throw new DorisException("Unsupported type " + dorisType)
+      case "HLL"             => DataTypes.BinaryType
+      case "BITMAP"          => DataTypes.BinaryType
       case _                 =>
         throw new DorisException("Unrecognized Doris type " + dorisType)
     }


### PR DESCRIPTION
# Proposed changes

when we export data from table which has HLL/BITMAP to iceberg table, we can not export the HLL and BITMAP column. we just want to export, as we have another way to query the HLL/BITMAP in Doris by give the column type HLL and BITMAP.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
