### PR TITLE
[fix] The result of serialization of decimal type does not meet the expected problem

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/DataUtil.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/DataUtil.java
@@ -17,10 +17,11 @@
 
 package org.apache.doris.spark.util;
 
-import org.apache.doris.spark.sql.SchemaUtils;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.scala.DefaultScalaModule;
+import org.apache.doris.spark.sql.SchemaUtils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -31,7 +32,7 @@ import java.util.Map;
 
 public class DataUtil {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapper.builder().addModule(new DefaultScalaModule()).build();
 
     public static final String NULL_VALUE = "\\N";
 
@@ -67,8 +68,7 @@ public class DataUtil {
         return builder.toString().getBytes(StandardCharsets.UTF_8);
     }
 
-    public static byte[] rowToJsonBytes(InternalRow row, StructType schema)
-            throws JsonProcessingException {
+    public static byte[] rowToJsonBytes(InternalRow row, StructType schema) throws JsonProcessingException {
         StructField[] fields = schema.fields();
         Map<String, Object> rowMap = new HashMap<>(row.numFields());
         for (int i = 0; i < fields.length; i++) {

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
@@ -168,7 +168,7 @@ private[spark] object SchemaUtils {
           new Timestamp(row.getLong(ordinal) / 1000).toString
         case DateType => DateTimeUtils.toJavaDate(row.getInt(ordinal)).toString
         case BinaryType => row.getBinary(ordinal)
-        case dt: DecimalType => row.getDecimal(ordinal, dt.precision, dt.scale)
+        case dt: DecimalType => row.getDecimal(ordinal, dt.precision, dt.scale).toJavaBigDecimal
         case at: ArrayType =>
           val arrayData = row.getArray(ordinal)
           if (arrayData == null) DataUtil.NULL_VALUE

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/writer/DorisWriter.scala
@@ -79,6 +79,10 @@ class DorisWriter(settings: SparkSettings) extends Serializable {
    * @param dataFrame source dataframe
    */
   def writeStream(dataFrame: DataFrame): Unit = {
+    if (enable2PC) {
+      val errMsg = "two phrase commit is not supported in stream mode, please set doris.sink.enable-2pc to false."
+      throw new UnsupportedOperationException(errMsg)
+    }
     doWrite(dataFrame, dorisStreamLoader.loadStream)
   }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The return type of `InternalRow.getDecimal` is `org.apache.spark.sql.types.Decimal`,  and its serialization result is `{"zero":false}`, which is not as expected.
Now convert `org.apache.spark.sql.types.Decimal` to `java.math.BigDecimal` so that the serialized result is correct.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
