### PR TITLE
[bugfix]fix schema error from unique table

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
@@ -105,8 +105,8 @@ public class RowBatch {
             VectorSchemaRoot root = arrowStreamReader.getVectorSchemaRoot();
             while (arrowStreamReader.loadNextBatch()) {
                 fieldVectors = root.getFieldVectors();
-                if (fieldVectors.size() != schema.size()) {
-                    logger.error("Schema size '{}' is not equal to arrow field size '{}'.",
+                if (fieldVectors.size() > schema.size()) {
+                    logger.error("Data schema size '{}' should not be bigger than arrow field size '{}'.",
                             fieldVectors.size(), schema.size());
                     throw new DorisException("Load Doris data failed, schema size of fetch data is wrong.");
                 }


### PR DESCRIPTION
# Proposed changes

For unique tables, `__DORIS_DELET_SIGN__` is a hidden column that needs to be read during data scanning, but should not be displayed

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
