### PR TITLE
[workflows] add other spark version to compile

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -42,18 +42,44 @@ jobs:
         java-version: '8'
         cache: 'maven'
 
-    - name: Build spark connector v2
+    - name: Build spark connector 2.3
       run: |
         cd spark-doris-connector && mvn clean package ${MVN_OPT} \
           -Dspark.version=2.3.4 \
           -Dscala.version=2.11 \
           -Dspark.major.version=2.3
 
-    - name: Build spark connector v3
+    - name: Build spark connector 2.4
+      run: |
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
+          -Dspark.version=2.4.0 \
+          -Dscala.version=2.11 \
+          -Dspark.major.version=2.4    
+
+    - name: Build spark connector 3.1
       run: |
         cd spark-doris-connector && mvn clean package ${MVN_OPT} \
           -Dspark.version=3.1.2 \
           -Dscala.version=2.12 \
           -Dspark.major.version=3.1
-          
 
+    - name: Build spark connector 3.2
+      run: |
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
+          -Dspark.version=3.2.0 \
+          -Dscala.version=2.12 \
+          -Dspark.major.version=3.2
+
+    - name: Build spark connector 3.3
+      run: |
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
+          -Dspark.version=3.3.0 \
+          -Dscala.version=2.12 \
+          -Dspark.major.version=3.3
+
+    - name: Build spark connector 3.4
+      run: |
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
+          -Dspark.version=3.4.0 \
+          -Dscala.version=2.12 \
+          -Dspark.major.version=3.4  

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -49,12 +49,19 @@ jobs:
           -Dscala.version=2.11 \
           -Dspark.major.version=2.3
 
-    - name: Build spark connector 2.4
+    - name: Build spark connector 2.4 2.11
       run: |
         cd spark-doris-connector && mvn clean package ${MVN_OPT} \
           -Dspark.version=2.4.0 \
           -Dscala.version=2.11 \
           -Dspark.major.version=2.4    
+
+    - name: Build spark connector 2.4 2.12
+      run: |
+        cd spark-doris-connector && mvn clean package ${MVN_OPT} \
+          -Dspark.version=2.4.0 \
+          -Dscala.version=2.12 \
+          -Dspark.major.version=2.4        
 
     - name: Build spark connector 3.1
       run: |

--- a/spark-doris-connector/pom.xml
+++ b/spark-doris-connector/pom.xml
@@ -76,7 +76,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>github</project.scm.id>
         <netty.version>4.1.77.Final</netty.version>
-        <fasterxml.jackson.version>2.10.5</fasterxml.jackson.version>
+        <fasterxml.jackson.version>2.13.5</fasterxml.jackson.version>
         <thrift-service.version>1.0.0</thrift-service.version>
         <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
@@ -118,6 +118,20 @@
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
             <version>${arrow.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-annotations</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-core</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

1. add spark2.4,3.2,3.3,3.4 to workflows
2. upgrade jackson version to 2.13
## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
