### PR TITLE
[fix] stream load's colunms can use keyword with sparksql

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/load/DorisStreamLoad.java
@@ -31,6 +31,7 @@ import org.apache.doris.spark.exception.StreamLoadException;
 import org.apache.doris.spark.rest.RestService;
 import org.apache.doris.spark.rest.models.BackendV2;
 import org.apache.doris.spark.rest.models.RespContent;
+import org.apache.doris.spark.sql.Utils;
 import org.apache.doris.spark.util.ResponseUtil;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -180,7 +181,7 @@ public class DorisStreamLoad implements Serializable {
             httpPut.setHeader("columns", columns);
         } else {
             if (schema != null && !schema.isEmpty()) {
-                String dfColumns = Arrays.stream(schema.fieldNames()).collect(Collectors.joining(","));
+                String dfColumns = Arrays.stream(schema.fieldNames()).map(Utils::quote).collect(Collectors.joining(","));
                 httpPut.setHeader("columns", dfColumns);
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
