### PR TITLE
[feature] support fe https request

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -132,4 +132,16 @@ public interface ConfigurationOptions {
      */
     String DORIS_SINK_DATA_COMPRESS_TYPE = "doris.sink.properties.compress_type";
 
+    String DORIS_ENABLE_HTTPS = "doris.enable.https";
+
+    boolean DORIS_ENABLE_HTTPS_DEFAULT = false;
+
+    String DORIS_HTTPS_KEY_STORE_PATH = "doris.https.key-store-path";
+
+    String DORIS_HTTPS_KEY_STORE_TYPE = "doris.https.key-store-type";
+
+    String DORIS_HTTPS_KEY_STORE_TYPE_DEFAULT = "JKS";
+
+    String DORIS_HTTPS_KEY_STORE_PASSWORD = "doris.https.key-store-password";
+
 }

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
@@ -74,8 +74,8 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
   private val autoRedirect: Boolean = settings.getBooleanProperty(ConfigurationOptions.DORIS_SINK_AUTO_REDIRECT,
     ConfigurationOptions.DORIS_SINK_AUTO_REDIRECT_DEFAULT)
 
-  require(settings.getBooleanProperty(ConfigurationOptions.DORIS_ENABLE_HTTPS,
-    ConfigurationOptions.DORIS_ENABLE_HTTPS_DEFAULT) && autoRedirect, "https must open with auto redirect")
+  require(if (settings.getBooleanProperty(ConfigurationOptions.DORIS_ENABLE_HTTPS,
+    ConfigurationOptions.DORIS_ENABLE_HTTPS_DEFAULT)) autoRedirect else true, "https must open with auto redirect")
 
   private val enableHttps: Boolean = settings.getBooleanProperty(ConfigurationOptions.DORIS_ENABLE_HTTPS,
     ConfigurationOptions.DORIS_ENABLE_HTTPS_DEFAULT) && autoRedirect

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/HttpUtil.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/HttpUtil.scala
@@ -1,0 +1,53 @@
+package org.apache.doris.spark.util
+
+import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.conn.ssl.{SSLConnectionSocketFactory, TrustAllStrategy}
+import org.apache.http.impl.client.{CloseableHttpClient, DefaultRedirectStrategy, HttpClients}
+import org.apache.http.ssl.SSLContexts
+
+import java.io.{File, FileInputStream}
+import java.security.KeyStore
+import scala.util.{Failure, Success, Try}
+
+object HttpUtil {
+
+  def getHttpClient(settings: SparkSettings): CloseableHttpClient = {
+    val connectTimeout = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS,
+      ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT)
+    val socketTimeout = settings.getIntegerProperty(ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS,
+      ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT)
+    val requestConfig = RequestConfig.custom().setConnectTimeout(connectTimeout).setSocketTimeout(socketTimeout).build()
+    val clientBuilder = HttpClients.custom()
+      .setRedirectStrategy(new DefaultRedirectStrategy {
+        override def isRedirectable(method: String): Boolean = true
+      })
+      .setDefaultRequestConfig(requestConfig)
+    val enableHttps = settings.getBooleanProperty("doris.enable.https", false)
+    if (enableHttps) {
+      val props = settings.asProperties()
+      require(props.containsKey(ConfigurationOptions.DORIS_HTTPS_KEY_STORE_PATH))
+      val keyStorePath: String = props.getProperty(ConfigurationOptions.DORIS_HTTPS_KEY_STORE_PATH)
+      val keyStoreFile = new File(keyStorePath)
+      if (!keyStoreFile.exists()) throw new IllegalArgumentException()
+      val keyStoreType: String = props.getProperty(ConfigurationOptions.DORIS_HTTPS_KEY_STORE_TYPE,
+        ConfigurationOptions.DORIS_HTTPS_KEY_STORE_TYPE_DEFAULT)
+      val keyStore = KeyStore.getInstance(keyStoreType)
+      var fis: FileInputStream = null
+      Try {
+        fis = new FileInputStream(keyStoreFile)
+        val password = props.getProperty(ConfigurationOptions.DORIS_HTTPS_KEY_STORE_PASSWORD)
+        keyStore.load(fis, if (password == null) null else password.toCharArray)
+      } match {
+        case Success(_) => if (fis != null) fis.close()
+        case Failure(e) =>
+          if (fis != null) fis.close()
+          throw e
+      }
+      val sslContext = SSLContexts.custom().loadTrustMaterial(keyStore, new TrustAllStrategy).build()
+      clientBuilder.setSSLSocketFactory(new SSLConnectionSocketFactory(sslContext))
+    }
+    clientBuilder.build()
+  }
+
+}

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/HttpUtil.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/HttpUtil.scala
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.spark.util
 
 import org.apache.doris.spark.cfg.{ConfigurationOptions, SparkSettings}

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/URLs.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/URLs.scala
@@ -1,0 +1,25 @@
+package org.apache.doris.spark.util
+
+object URLs {
+
+  private val HTTP_SCHEMA = "http"
+
+  private val HTTPS_SCHEMA = "https"
+
+  private def schema(enableHttps: Boolean): String = if (enableHttps) HTTPS_SCHEMA else HTTP_SCHEMA
+
+  def aliveBackend(feNode: String, enableHttps: Boolean = false) = s"${schema(enableHttps)}://$feNode/api/backends?is_alive=true"
+
+  def tableSchema(feNode: String, database: String, table: String, enableHttps: Boolean = false) =
+    s"${schema(enableHttps)}://$feNode/api/$database/$table/_schema"
+
+  def queryPlan(feNode: String, database: String, table: String, enableHttps: Boolean = false) =
+    s"${schema(enableHttps)}://$feNode/api/$database/$table/_query_plan"
+
+  def streamLoad(feNode: String, database: String, table: String, enableHttps: Boolean = false) =
+    s"${schema(enableHttps)}://$feNode/api/$database/$table/_stream_load"
+
+  def streamLoad2PC(feNode: String, database: String, enableHttps: Boolean = false) =
+    s"${schema(enableHttps)}://$feNode/api/$database/_stream_load_2pc"
+
+}

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/URLs.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/util/URLs.scala
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.spark.util
 
 object URLs {

--- a/spark-doris-connector/src/test/java/org/apache/doris/spark/load/StreamLoaderTest.java
+++ b/spark-doris-connector/src/test/java/org/apache/doris/spark/load/StreamLoaderTest.java
@@ -1,0 +1,37 @@
+package org.apache.doris.spark.load;
+
+import org.apache.doris.spark.cfg.ConfigurationOptions;
+import org.apache.doris.spark.cfg.SparkSettings;
+import org.apache.spark.SparkConf;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class StreamLoaderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEnableHttpsWithoutAutoRedirect() {
+        SparkConf sparkConf = new SparkConf();
+        sparkConf.set(ConfigurationOptions.DORIS_ENABLE_HTTPS, "true");
+        sparkConf.set(ConfigurationOptions.DORIS_TABLE_IDENTIFIER, "db.table");
+        sparkConf.set(ConfigurationOptions.DORIS_SINK_AUTO_REDIRECT, "false");
+        new StreamLoader(new SparkSettings(sparkConf), false);
+        sparkConf.set(ConfigurationOptions.DORIS_SINK_AUTO_REDIRECT, "true");
+        new StreamLoader(new SparkSettings(sparkConf), false);
+
+    }
+
+    @Test
+    public void testEnableHttpsWithAutoRedirect() {
+        SparkConf sparkConf = new SparkConf();
+        sparkConf.set(ConfigurationOptions.DORIS_ENABLE_HTTPS, "true");
+        sparkConf.set(ConfigurationOptions.DORIS_TABLE_IDENTIFIER, "db.table");
+        sparkConf.set(ConfigurationOptions.DORIS_SINK_AUTO_REDIRECT, "true");
+        new StreamLoader(new SparkSettings(sparkConf), false);
+
+    }
+
+}

--- a/spark-doris-connector/src/test/scala/org/apache/doris/spark/load/StreamLoaderTest.java
+++ b/spark-doris-connector/src/test/scala/org/apache/doris/spark/load/StreamLoaderTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package org.apache.doris.spark.load;
 
 import org.apache.doris.spark.cfg.ConfigurationOptions;


### PR DESCRIPTION
# Proposed changes

Issue Number: #124

## Problem Summary:

1. Support FE https request.
You can set the following options to enable https: 
    - Set `doris.enable.https` to `true`
    - Set `doris.https.key-store-path` to the file path of a valid ssl certificate
    - Set `doris.https.key-store-type` to the certificate type, the default value is `JKS`
    - Set `doris.https.key-store-password` to certificate file password
Note: 
        - Since BE does not currently support https, stream load through https only supports redirection by FE (setting the `doris.sink.auto-redirect` option to `true`,  which is the default value)

2. Refactor RestService 

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
