### PR TITLE
[Improvement]Put generateSerializedResult in try catch to avoid insufficient memory caused by excessive data size

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/util/ListUtils.java
@@ -44,13 +44,12 @@ public class ListUtils {
      * recursively splits large collections to normal collection and serializes the collection
      * @param batch
      * @param result
-     * @throws JsonProcessingException
      */
-    public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result, String lineDelimiter)
-            throws JsonProcessingException {
-        String serializedResult = generateSerializedResult(batch, lineDelimiter);
+    public static void divideAndSerialize(List<Map<Object, Object>> batch, List<String> result, String lineDelimiter) {
+
         // if an error occurred in the batch call to getBytes ,average divide the batch
         try {
+            String serializedResult = generateSerializedResult(batch, lineDelimiter);
             //the "Requested array size exceeds VM limit" exception occurs when the collection is large
             serializedResult.getBytes("UTF-8");
             result.add(serializedResult);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem Summary:
When a batch of data is too large, it will cause OOM when generatingSerializedResult, but also it is not in trycatch, a batch of data cannot be divided.
![cf05a261a8f4d2338b9cfd2fca9f2af](https://github.com/apache/doris-spark-connector/assets/22031277/6e829af7-6f3d-4003-b7a5-abd0dc8cdaa6)

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
