### PR TITLE
[bug] fix bitmap and hll type column access issue

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -93,13 +93,6 @@ public interface ConfigurationOptions {
 
     int DORIS_SINK_BATCH_INTERVAL_MS_DEFAULT = 50;
 
-    /**
-     * set types to ignore, split by comma
-     * e.g.
-     * "doris.ignore-type"="bitmap,hll"
-     */
-    String DORIS_IGNORE_TYPE = "doris.ignore-type";
-
     String DORIS_SINK_ENABLE_2PC = "doris.sink.enable-2pc";
     boolean DORIS_SINK_ENABLE_2PC_DEFAULT = false;
 

--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/serialization/RowBatch.java
@@ -17,6 +17,11 @@
 
 package org.apache.doris.spark.serialization;
 
+import org.apache.doris.sdk.thrift.TScanBatchResult;
+import org.apache.doris.spark.exception.DorisException;
+import org.apache.doris.spark.rest.models.Schema;
+import org.apache.doris.spark.util.IPUtils;
+
 import com.google.common.base.Preconditions;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BaseIntVector;
@@ -43,10 +48,6 @@ import org.apache.arrow.vector.complex.impl.UnionMapReader;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.Types;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.doris.sdk.thrift.TScanBatchResult;
-import org.apache.doris.spark.exception.DorisException;
-import org.apache.doris.spark.rest.models.Schema;
-import org.apache.doris.spark.util.IPUtils;
 import org.apache.spark.sql.types.Decimal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,8 +72,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-
-import static org.apache.doris.spark.util.IPUtils.convertLongToIPv4Address;
 
 /**
  * row batch data container.
@@ -157,8 +156,7 @@ public class RowBatch {
 
     private void addValueToRow(int rowIndex, Object obj) {
         if (rowIndex > rowCountInOneBatch) {
-            String errMsg = "Get row offset: " + rowIndex + " larger than row size: " +
-                    rowCountInOneBatch;
+            String errMsg = "Get row offset: " + rowIndex + " larger than row size: " + rowCountInOneBatch;
             logger.error(errMsg);
             throw new NoSuchElementException(errMsg);
         }
@@ -261,7 +259,8 @@ public class RowBatch {
                             ipv4Vector = (UInt4Vector) curFieldVector;
                         }
                         for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = ipv4Vector.isNull(rowIndex) ? null : convertLongToIPv4Address(ipv4Vector.getValueAsLong(rowIndex));
+                            Object fieldValue = ipv4Vector.isNull(rowIndex) ? null :
+                                    IPUtils.convertLongToIPv4Address(ipv4Vector.getValueAsLong(rowIndex));
                             addValueToRow(rowIndex, fieldValue);
                         }
                         break;

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/ScalaValueReader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/rdd/ScalaValueReader.scala
@@ -138,7 +138,7 @@ class ScalaValueReader(partition: PartitionDefinition, settings: Settings) exten
   protected val openResult: TScanOpenResult = lockClient(_.openScanner(openParams))
   protected val contextId: String = openResult.getContextId
   protected val schema: Schema =
-    SchemaUtils.convertToSchema(openResult.getSelectedColumns)
+    SchemaUtils.convertToSchema(openResult.getSelectedColumns, settings)
 
   private[this] val asyncThread: Thread = new Thread {
     override def run(): Unit = {

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisRelation.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/DorisRelation.scala
@@ -70,6 +70,11 @@ private[sql] class DorisRelation(
           .map(filter => s"($filter)").mkString(" and ")
     }
 
+    val bitmapColumnStr = cfg.getProperty(SchemaUtils.DORIS_BITMAP_COLUMNS, "")
+    paramWithScan += (SchemaUtils.DORIS_BITMAP_COLUMNS -> bitmapColumnStr)
+    val hllColumnStr = cfg.getProperty(SchemaUtils.DORIS_HLL_COLUMNS, "")
+    paramWithScan += (SchemaUtils.DORIS_HLL_COLUMNS -> hllColumnStr)
+
     // required columns for column pruner
     if (requiredColumns != null && requiredColumns.length > 0) {
       paramWithScan += (ConfigurationOptions.DORIS_READ_FIELD ->

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/sql/SchemaUtils.scala
@@ -147,9 +147,9 @@ private[spark] object SchemaUtils {
    * @return inner schema struct
    */
   def convertToSchema(tscanColumnDescs: Seq[TScanColumnDesc], settings: Settings): Schema = {
-    val readColumns = settings.getProperty(DORIS_READ_FIELD, "").split(",").map(_.replaceAll("`", ""))
-    val bitmapColumns = settings.getProperty(DORIS_BITMAP_COLUMNS, "").split(",")
-    val hllColumns = settings.getProperty(DORIS_HLL_COLUMNS, "").split(",")
+    val readColumns = settings.getProperty(DORIS_READ_FIELD, "").split(",").filter(_.nonEmpty).map(_.replaceAll("`", ""))
+    val bitmapColumns = settings.getProperty(DORIS_BITMAP_COLUMNS, "").split(",").filter(_.nonEmpty)
+    val hllColumns = settings.getProperty(DORIS_HLL_COLUMNS, "").split(",").filter(_.nonEmpty)
     val fieldList = fieldUnion(readColumns, bitmapColumns, hllColumns, tscanColumnDescs)
     val schema = new Schema(fieldList.length)
     fieldList.foreach(schema.put)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

For the `bitmap` type, doris does not currently support reading, so the previous implementation method is to ignore the `bitmap` type field by setting the `doris.ignore-type` option.
However, when you import data into Doris by executing the `insert into select` statement, the source table and the target table have the same number of columns, and you need to map the source table columns to columns of the Doris bitmap type, the number of select columns and the number of target table columns will be inconsistent, causing Spark parsing failure.
So now the solution is as follows：
- When reading, the `bitmap` and `HLL `type columns will return the string constant 'READ UNSUPPORTED'.
- When writing, `bitmap` and `HLL` type columns are converted to bitmap type by specifying function mapping using the doris.write.fields option.
- `doris.ignore-type` option will be removed

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
