### PR TITLE
[Enhancemant] add label prefix configuration item for doris sink to track writing s…

### DIFF
--- a/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
+++ b/spark-doris-connector/src/main/java/org/apache/doris/spark/cfg/ConfigurationOptions.java
@@ -126,6 +126,9 @@ public interface ConfigurationOptions {
     String DORIS_SINK_AUTO_REDIRECT = "doris.sink.auto-redirect";
     boolean DORIS_SINK_AUTO_REDIRECT_DEFAULT = true;
 
+    String DORIS_SINK_LABEL_PREFIX = "doris.sink.label.prefix";
+    String DORIS_SINK_LABEL_PREFIX_DEFAULT = "spark_streamload";
+
     /**
      * compress_type
      */

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
@@ -394,7 +394,8 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
       return null;
     }
     val calendar = Calendar.getInstance
-    val labelPrefix = streamLoadProps.getOrElse("label_prefix", "spark_streamload")
+    val labelPrefix = settings.getProperty(ConfigurationOptions.DORIS_SINK_LABEL_PREFIX,
+      ConfigurationOptions.DORIS_SINK_LABEL_PREFIX_DEFAULT)
     labelPrefix + "_" +
       f"${calendar.get(Calendar.YEAR)}${calendar.get(Calendar.MONTH) + 1}%02d${calendar.get(Calendar.DAY_OF_MONTH)}%02d" +
       f"_${calendar.get(Calendar.HOUR_OF_DAY)}%02d${calendar.get(Calendar.MINUTE)}%02d${calendar.get(Calendar.SECOND)}%02d" +

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
@@ -312,7 +312,7 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
    *
    * if load data to be directly, check node available will be done before return.
    *
-   * @throws [       [       org.apache.doris.spark.exception.StreamLoadException]]
+   * @throws [ [ org.apache.doris.spark.exception.StreamLoadException]]
    * @return address
    */
   @throws[StreamLoadException]

--- a/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
+++ b/spark-doris-connector/src/main/scala/org/apache/doris/spark/load/StreamLoader.scala
@@ -83,6 +83,7 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
     ConfigurationOptions.DORIS_ENABLE_HTTPS_DEFAULT) && autoRedirect
 
   private val enableGroupCommit: Boolean = streamLoadProps.contains(ConfigurationOptions.GROUP_COMMIT)
+
   /**
    * execute stream load
    *
@@ -311,7 +312,7 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
    *
    * if load data to be directly, check node available will be done before return.
    *
-   * @throws [ [ org.apache.doris.spark.exception.StreamLoadException]]
+   * @throws [       [       org.apache.doris.spark.exception.StreamLoadException]]
    * @return address
    */
   @throws[StreamLoadException]
@@ -384,7 +385,7 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
   /**
    * generate load label
    *
-   * spark_streamload_YYYYMMDD_HHMMSS_{UUID}
+   * {label_prefix}_YYYYMMDD_HHMMSS_{UUID}
    *
    * @return load label
    */
@@ -393,7 +394,8 @@ class StreamLoader(settings: SparkSettings, isStreaming: Boolean) extends Loader
       return null;
     }
     val calendar = Calendar.getInstance
-    "spark_streamload_" +
+    val labelPrefix = streamLoadProps.getOrElse("label_prefix", "spark_streamload")
+    labelPrefix + "_" +
       f"${calendar.get(Calendar.YEAR)}${calendar.get(Calendar.MONTH) + 1}%02d${calendar.get(Calendar.DAY_OF_MONTH)}%02d" +
       f"_${calendar.get(Calendar.HOUR_OF_DAY)}%02d${calendar.get(Calendar.MINUTE)}%02d${calendar.get(Calendar.SECOND)}%02d" +
       f"_${UUID.randomUUID.toString.replaceAll("-", "")}"


### PR DESCRIPTION


# Proposed changes

add configuration item label_prefix for spark doris sink for tracking writing source when troubleshooting 

## Problem Summary:

In current version of spark doris sink, the label generation strategy is `spark_streamload_YYYYMMDD_HHMMSS_{UUID}`, if the doris cluster becomes unstable due to some spark writing tasks, it will be difficult to find the spark writing task. using this configuration item, we can configure some value with business meanings to allow us to locate the writing task quickly. for example we can configure this item to the application id of the writing task.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
