### PR TITLE
[fix](connector) fix no suitable driver found issue when getting fe jdbc connection 

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/DorisFrontendClient.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/DorisFrontendClient.java
@@ -173,6 +173,11 @@ public class DorisFrontendClient implements Serializable {
                 ex = new OptionRequiredException(DorisOptions.DORIS_QUERY_PORT.getName());
                 break;
             }
+            try {
+                Class.forName("com.mysql.cj.jdbc.Driver");
+            } catch (ClassNotFoundException e) {
+                Class.forName("com.mysql.jdbc.Driver");
+            }
             try (Connection conn = DriverManager.getConnection("jdbc:mysql://" + frontEnd.getHost() + ":" + frontEnd.getQueryPort(), username, password)) {
                 return function.apply(conn);
             } catch (SQLException e) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Sometimes, even though the MySQL driver jar is included in the classpath, a "No suitable driver found" exception is thrown when calling the `DriverManager.getConnection` method.
So it is still necessary to call the `Class.forName` method to load the driver before getting the connection.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
