### PR TITLE
[fix](connector) fix read date type convert issue

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/RowConvertors.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/RowConvertors.scala
@@ -109,7 +109,7 @@ object RowConvertors {
     dataType match {
       case StringType => UTF8String.fromString(v.asInstanceOf[String])
       case TimestampType => DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(v.asInstanceOf[String]))
-      case DateType => DateTimeUtils.fromJavaDate(Date.valueOf(v.asInstanceOf[String]))
+      case DateType => DateTimeUtils.fromJavaDate(v.asInstanceOf[Date])
       case _: MapType =>
         val map = v.asInstanceOf[Map[String, String]]
         val keys = map.keys.toArray


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

For DATE/DATEV2 types, the data is converted to java.sql.Date type in RowBatch. 

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
