### PR TITLE
[fix](connector) remove arrow jdbc dependency

### DIFF
--- a/spark-doris-connector/pom.xml
+++ b/spark-doris-connector/pom.xml
@@ -237,6 +237,10 @@
                         <groupId>com.google.guava</groupId>
                         <artifactId>guava</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.arrow</groupId>
+                        <artifactId>flight-sql-jdbc-driver</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -278,12 +282,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-unix-common</artifactId>
                 <version>${netty.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.arrow</groupId>
-                <artifactId>flight-sql-jdbc-core</artifactId>
-                <version>${arrow.version}</version>
             </dependency>
 
             <dependency>

--- a/spark-doris-connector/spark-doris-connector-base/pom.xml
+++ b/spark-doris-connector/spark-doris-connector-base/pom.xml
@@ -136,12 +136,11 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>flight-sql-jdbc-driver</artifactId>
+                </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>flight-sql-jdbc-core</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

```scala
scala> Class.forName("com.mysql.jdbc.Driver")
25/01/06 12:48:38 ERROR : Error loading factory org.apache.doris.shaded.org.apache.arrow.driver.jdbc.ArrowFlightJdbcFactory
java.lang.ClassNotFoundException: org.apache.doris.shaded.org.apache.arrow.driver.jdbc.ArrowFlightJdbcFactory
        at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:264)
        at org.apache.calcite.avatica.UnregisteredDriver.instantiateFactory(UnregisteredDriver.java:115)
        at org.apache.calcite.avatica.UnregisteredDriver.createFactory(UnregisteredDriver.java:74)
        at org.apache.calcite.avatica.UnregisteredDriver.<init>(UnregisteredDriver.java:55)
        at org.apache.doris.shaded.org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver.<init>(ArrowFlightJdbcDriver.java:49)
        at org.apache.doris.shaded.org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver.<clinit>(ArrowFlightJdbcDriver.java:66)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at java.lang.Class.newInstance(Class.java:442)
        at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380)
        at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
        at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
        at java.sql.DriverManager$2.run(DriverManager.java:603)
        at java.sql.DriverManager$2.run(DriverManager.java:583)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.sql.DriverManager.loadInitialDrivers(DriverManager.java:583)
        at java.sql.DriverManager.<clinit>(DriverManager.java:101)
        at com.mysql.cj.jdbc.Driver.<clinit>(Driver.java:55)
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:264)
        at $line15.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:27)
        at $line15.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:32)
        at $line15.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:34)
        at $line15.$read$$iw$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:36)
        at $line15.$read$$iw$$iw$$iw$$iw$$iw$$iw.<init>(<console>:38)
        at $line15.$read$$iw$$iw$$iw$$iw$$iw.<init>(<console>:40)
        at $line15.$read$$iw$$iw$$iw$$iw.<init>(<console>:42)
        at $line15.$read$$iw$$iw$$iw.<init>(<console>:44)
        at $line15.$read$$iw$$iw.<init>(<console>:46)
        at $line15.$read$$iw.<init>(<console>:48)
        at $line15.$read.<init>(<console>:50)
        at $line15.$read$.<init>(<console>:54)
        at $line15.$read$.<clinit>(<console>)
        at $line15.$eval$.$print$lzycompute(<console>:7)
        at $line15.$eval$.$print(<console>:6)
        at $line15.$eval.$print(<console>)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.call(IMain.scala:793)
        at scala.tools.nsc.interpreter.IMain$Request.loadAndRun(IMain.scala:1054)
        at scala.tools.nsc.interpreter.IMain$WrappedRequest$$anonfun$loadAndRunReq$1.apply(IMain.scala:645)
        at scala.tools.nsc.interpreter.IMain$WrappedRequest$$anonfun$loadAndRunReq$1.apply(IMain.scala:644)
        at scala.reflect.internal.util.ScalaClassLoader$class.asContext(ScalaClassLoader.scala:31)
        at scala.reflect.internal.util.AbstractFileClassLoader.asContext(AbstractFileClassLoader.scala:19)
        at scala.tools.nsc.interpreter.IMain$WrappedRequest.loadAndRunReq(IMain.scala:644)
        at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:576)
        at scala.tools.nsc.interpreter.IMain.interpret(IMain.scala:572)
        at scala.tools.nsc.interpreter.ILoop.interpretStartingWith(ILoop.scala:819)
        at scala.tools.nsc.interpreter.ILoop.command(ILoop.scala:691)
        at scala.tools.nsc.interpreter.ILoop.processLine(ILoop.scala:404)
        at scala.tools.nsc.interpreter.ILoop.loop(ILoop.scala:425)
        at org.apache.spark.repl.SparkILoop$$anonfun$process$1.apply$mcZ$sp(SparkILoop.scala:285)
        at org.apache.spark.repl.SparkILoop.runClosure(SparkILoop.scala:159)
        at org.apache.spark.repl.SparkILoop.process(SparkILoop.scala:182)
        at org.apache.spark.repl.Main$.doMain(Main.scala:78)
        at org.apache.spark.repl.Main$.main(Main.scala:58)
        at org.apache.spark.repl.Main.main(Main.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
        at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:855)
        at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:161)
        at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:184)
        at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:86)
        at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:930)
        at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:939)
        at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```

Since arrow jdbc related dependencies have been shaded, arrow jdbc driver initialization exception will be thrown when loading other jdbc drivers, and arrow jdbc driver is not used, so remove related dependencies.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
