### PR TITLE
[improvement](connector) support doris spark sql datasource for create table statement in spark 3.3 and above

### DIFF
--- a/spark-doris-connector/spark-doris-connector-spark-3.3/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3.3/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
@@ -22,7 +22,7 @@ import org.apache.doris.spark.config.DorisConfig
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.types.StructType
 
-class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with Serializable {
+class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with DorisSourceProvider with Serializable {
 
   override def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table =
     new DorisTable(identifier, config, schema)

--- a/spark-doris-connector/spark-doris-connector-spark-3.4/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3.4/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
@@ -22,7 +22,7 @@ import org.apache.doris.spark.config.DorisConfig
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.types.StructType
 
-class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with Serializable {
+class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with DorisSourceProvider with Serializable {
 
   override def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table =
     new DorisTable(identifier, config, schema)

--- a/spark-doris-connector/spark-doris-connector-spark-3.5/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3.5/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
@@ -22,7 +22,7 @@ import org.apache.doris.spark.config.DorisConfig
 import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 import org.apache.spark.sql.types.StructType
 
-class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with Serializable {
+class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with DorisSourceProvider with Serializable {
 
   override def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table =
     new DorisTable(identifier, config, schema)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

when execute create table using doris, and query the table, the following exception will be thrown
```java
org.apache.spark.sql.AnalysisException: doris is not a valid Spark SQL Data 
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
