### PR TITLE
[fix](connector) fix read date type err

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/DorisReaderPartition.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/DorisReaderPartition.java
@@ -34,8 +34,10 @@ public class DorisReaderPartition implements Serializable {
     private final String[] filters;
     private final Integer limit;
     private final DorisConfig config;
+    private final Boolean datetimeJava8ApiEnabled;
 
-    public DorisReaderPartition(String database, String table, Backend backend, Long[] tablets, String opaquedQueryPlan, String[] readColumns, String[] filters, DorisConfig config) {
+    public DorisReaderPartition(String database, String table, Backend backend, Long[] tablets, String opaquedQueryPlan,
+                                String[] readColumns, String[] filters, DorisConfig config, Boolean datetimeJava8ApiEnabled) {
         this.database = database;
         this.table = table;
         this.backend = backend;
@@ -45,9 +47,11 @@ public class DorisReaderPartition implements Serializable {
         this.filters = filters;
         this.limit = -1;
         this.config = config;
+        this.datetimeJava8ApiEnabled = datetimeJava8ApiEnabled;
     }
 
-    public DorisReaderPartition(String database, String table, Backend backend, Long[] tablets, String opaquedQueryPlan, String[] readColumns, String[] filters, Integer limit, DorisConfig config) {
+    public DorisReaderPartition(String database, String table, Backend backend, Long[] tablets, String opaquedQueryPlan,
+                                String[] readColumns, String[] filters, Integer limit, DorisConfig config, Boolean datetimeJava8ApiEnabled) {
         this.database = database;
         this.table = table;
         this.backend = backend;
@@ -57,6 +61,7 @@ public class DorisReaderPartition implements Serializable {
         this.filters = filters;
         this.limit = limit;
         this.config = config;
+        this.datetimeJava8ApiEnabled = datetimeJava8ApiEnabled;
     }
 
     // Getters and Setters
@@ -96,6 +101,10 @@ public class DorisReaderPartition implements Serializable {
         return limit;
     }
 
+    public Boolean getDateTimeJava8APIEnabled() {
+        return datetimeJava8ApiEnabled;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -108,11 +117,13 @@ public class DorisReaderPartition implements Serializable {
                 && Objects.deepEquals(readColumns, that.readColumns)
                 && Objects.deepEquals(filters, that.filters)
                 && Objects.equals(limit, that.limit)
-                && Objects.equals(config, that.config);
+                && Objects.equals(config, that.config)
+                && Objects.equals(datetimeJava8ApiEnabled, that.datetimeJava8ApiEnabled);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(database, table, backend, Arrays.hashCode(tablets), opaquedQueryPlan, Arrays.hashCode(readColumns), Arrays.hashCode(filters), limit, config);
+        return Objects.hash(database, table, backend, Arrays.hashCode(tablets), opaquedQueryPlan,
+                Arrays.hashCode(readColumns), Arrays.hashCode(filters), limit, config, datetimeJava8ApiEnabled);
     }
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/AbstractThriftReader.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/AbstractThriftReader.java
@@ -73,6 +73,8 @@ public abstract class AbstractThriftReader extends DorisReader {
 
     private int readCount = 0;
 
+    private final Boolean datetimeJava8ApiEnabled;
+
     protected AbstractThriftReader(DorisReaderPartition partition) throws Exception {
         super(partition);
         this.frontend = new DorisFrontendClient(config);
@@ -108,6 +110,7 @@ public abstract class AbstractThriftReader extends DorisReader {
             this.rowBatchQueue = null;
             this.asyncThread = null;
         }
+        this.datetimeJava8ApiEnabled = false;
     }
 
     private void runAsync() throws DorisException, InterruptedException {
@@ -124,7 +127,7 @@ public abstract class AbstractThriftReader extends DorisReader {
             });
             endOfStream.set(nextResult.isEos());
             if (!endOfStream.get()) {
-                rowBatch = new RowBatch(nextResult, dorisSchema);
+                rowBatch = new RowBatch(nextResult, dorisSchema, datetimeJava8ApiEnabled);
                 offset += rowBatch.getReadRowCount();
                 rowBatch.close();
                 rowBatchQueue.put(rowBatch);
@@ -178,7 +181,7 @@ public abstract class AbstractThriftReader extends DorisReader {
                 });
                 endOfStream.set(nextResult.isEos());
                 if (!endOfStream.get()) {
-                    rowBatch = new RowBatch(nextResult, dorisSchema);
+                    rowBatch = new RowBatch(nextResult, dorisSchema, datetimeJava8ApiEnabled);
                 }
             }
             hasNext = !endOfStream.get();

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/DorisFlightSqlReader.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/DorisFlightSqlReader.java
@@ -59,6 +59,7 @@ public class DorisFlightSqlReader extends DorisReader {
     private final Schema schema;
     private AdbcConnection connection;
     private final ArrowReader arrowReader;
+    private final Boolean datetimeJava8ApiEnabled;
 
     public DorisFlightSqlReader(DorisReaderPartition partition) throws Exception {
         super(partition);
@@ -74,6 +75,7 @@ public class DorisFlightSqlReader extends DorisReader {
         }
         this.schema = processDorisSchema(partition);
         this.arrowReader = executeQuery();
+        this.datetimeJava8ApiEnabled = partition.getDateTimeJava8APIEnabled();
     }
 
     @Override
@@ -85,7 +87,7 @@ public class DorisFlightSqlReader extends DorisReader {
                 throw new DorisException(e);
             }
             if (!endOfStream.get()) {
-                rowBatch = new RowBatch(arrowReader, schema);
+                rowBatch = new RowBatch(arrowReader, schema, datetimeJava8ApiEnabled);
             }
         }
         return !endOfStream.get();

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/rdd/AbstractDorisRDD.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/rdd/AbstractDorisRDD.scala
@@ -51,7 +51,9 @@ protected[spark] abstract class AbstractDorisRDD[T: ClassTag](
    */
   @transient private[spark] lazy val dorisCfg = DorisConfig.fromMap(sc.getConf.getAll.toMap.asJava, params.asJava, false)
 
-  @transient private[spark] lazy val dorisPartitions = ReaderPartitionGenerator.generatePartitions(dorisCfg)
+  @transient private[spark] lazy val dateTimeJava8ApiEnabled = sc.getConf.get("spark.sql.datetime.java8API.enabled", "false").toBoolean
+
+  @transient private[spark] lazy val dorisPartitions = ReaderPartitionGenerator.generatePartitions(dorisCfg, dateTimeJava8ApiEnabled)
 }
 
 private[spark] class DorisPartition(rddId: Int, idx: Int, val dorisPartition: DorisReaderPartition)

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/RowConvertors.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/RowConvertors.scala
@@ -111,7 +111,7 @@ object RowConvertors {
     dataType match {
       case StringType => UTF8String.fromString(v.asInstanceOf[String])
       case TimestampType => DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(v.asInstanceOf[String]))
-      case DateType if datetimeJava8ApiEnabled => DateTimeUtils.localDateToDays(v.asInstanceOf[LocalDate])
+      case DateType if datetimeJava8ApiEnabled => v.asInstanceOf[LocalDate].toEpochDay.toInt
       case DateType => DateTimeUtils.fromJavaDate(v.asInstanceOf[Date])
       case _: MapType =>
         val map = v.asInstanceOf[Map[String, String]]

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/RowConvertors.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/RowConvertors.scala
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, DateTimeUtils}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.sql.{Date, Timestamp}
+import java.time.LocalDate
 import scala.collection.mutable
 
 object RowConvertors {
@@ -105,10 +107,11 @@ object RowConvertors {
     }
   }
 
-  def convertValue(v: Any, dataType: DataType): Any = {
+  def convertValue(v: Any, dataType: DataType, datetimeJava8ApiEnabled: Boolean): Any = {
     dataType match {
       case StringType => UTF8String.fromString(v.asInstanceOf[String])
       case TimestampType => DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf(v.asInstanceOf[String]))
+      case DateType if datetimeJava8ApiEnabled => DateTimeUtils.localDateToDays(v.asInstanceOf[LocalDate])
       case DateType => DateTimeUtils.fromJavaDate(v.asInstanceOf[Date])
       case _: MapType =>
         val map = v.asInstanceOf[Map[String, String]]

--- a/spark-doris-connector/spark-doris-connector-base/src/test/scala/org/apache/doris/spark/util/RowConvertorsTest.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/scala/org/apache/doris/spark/util/RowConvertorsTest.scala
@@ -25,6 +25,7 @@ import org.junit.Assert
 import org.junit.jupiter.api.Test
 
 import java.sql.{Date, Timestamp}
+import java.time.LocalDate
 
 class RowConvertorsTest {
 
@@ -103,16 +104,17 @@ class RowConvertorsTest {
 
   @Test def convertValue(): Unit = {
 
-    Assert.assertTrue(RowConvertors.convertValue(1, DataTypes.IntegerType).isInstanceOf[Int])
-    Assert.assertTrue(RowConvertors.convertValue(2.3.toFloat, DataTypes.FloatType).isInstanceOf[Float])
-    Assert.assertTrue(RowConvertors.convertValue(4.5, DataTypes.DoubleType).isInstanceOf[Double])
-    Assert.assertTrue(RowConvertors.convertValue(6.toShort, DataTypes.ShortType).isInstanceOf[Short])
-    Assert.assertTrue(RowConvertors.convertValue(7L, DataTypes.LongType).isInstanceOf[Long])
-    Assert.assertTrue(RowConvertors.convertValue(Decimal(BigDecimal(8910.11), 20, 4), DecimalType(20, 4)).isInstanceOf[Decimal])
-    Assert.assertTrue(RowConvertors.convertValue("2024-01-01", DataTypes.DateType).isInstanceOf[Int])
-    Assert.assertTrue(RowConvertors.convertValue("2024-01-01 12:34:56", DataTypes.TimestampType).isInstanceOf[Long])
-    Assert.assertTrue(RowConvertors.convertValue(Map[String, String]("a" -> "1"), MapType(DataTypes.StringType, DataTypes.StringType)).isInstanceOf[MapData])
-    Assert.assertTrue(RowConvertors.convertValue("test", DataTypes.StringType).isInstanceOf[UTF8String])
+    Assert.assertTrue(RowConvertors.convertValue(1, DataTypes.IntegerType, false).isInstanceOf[Int])
+    Assert.assertTrue(RowConvertors.convertValue(2.3.toFloat, DataTypes.FloatType, false).isInstanceOf[Float])
+    Assert.assertTrue(RowConvertors.convertValue(4.5, DataTypes.DoubleType, false).isInstanceOf[Double])
+    Assert.assertTrue(RowConvertors.convertValue(6.toShort, DataTypes.ShortType, false).isInstanceOf[Short])
+    Assert.assertTrue(RowConvertors.convertValue(7L, DataTypes.LongType, false).isInstanceOf[Long])
+    Assert.assertTrue(RowConvertors.convertValue(Decimal(BigDecimal(8910.11), 20, 4), DecimalType(20, 4), false).isInstanceOf[Decimal])
+    Assert.assertTrue(RowConvertors.convertValue(Date.valueOf("2024-01-01"), DataTypes.DateType, false).isInstanceOf[Int])
+    Assert.assertTrue(RowConvertors.convertValue(LocalDate.now(), DataTypes.DateType, true).isInstanceOf[Int])
+    Assert.assertTrue(RowConvertors.convertValue("2024-01-01 12:34:56", DataTypes.TimestampType, false).isInstanceOf[Long])
+    Assert.assertTrue(RowConvertors.convertValue(Map[String, String]("a" -> "1"), MapType(DataTypes.StringType, DataTypes.StringType), false).isInstanceOf[MapData])
+    Assert.assertTrue(RowConvertors.convertValue("test", DataTypes.StringType, false).isInstanceOf[UTF8String])
 
   }
 

--- a/spark-doris-connector/spark-doris-connector-spark-2/pom.xml
+++ b/spark-doris-connector/spark-doris-connector-spark-2/pom.xml
@@ -35,10 +35,6 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spark.version>2.4.8</spark.version>
-        <spark.major.version>2.4</spark.major.version>
-        <scala.version>2.11.12</scala.version>
-        <scala.major.version>2.11</scala.major.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When `spark.sql.datetime.java8API.enabled` is configured as `true`, reading the data of date type will throw the following exception

```java
java.lang.RuntimeException: java.sql.Date is not a valid external type for schema of date
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
