### PR TITLE
[improvement](connector) support write accept any schema

### DIFF
--- a/spark-doris-connector/spark-doris-connector-spark-3-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableBase.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableBase.scala
@@ -47,7 +47,8 @@ abstract class DorisTableBase(identifier: Identifier, config: DorisConfig, schem
   override def capabilities(): util.Set[TableCapability] = {
     Set(BATCH_READ,
       BATCH_WRITE,
-      STREAMING_WRITE).asJava
+      STREAMING_WRITE,
+      ACCEPT_ANY_SCHEMA).asJava
   }
 
   override def newScanBuilder(caseInsensitiveStringMap: CaseInsensitiveStringMap): ScanBuilder = {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

In the spark 3.x connector, the Doris data source based on Datasource V2 is implemented. When the source schema written is different from the schema of the target table, an exception similar to the following will be thrown:
```java
org.apache.spark.sql.AnalysisException: Cannot write incompatible data to table 'db.table':
- Cannot find data for output column 'c0'
- Cannot find data for output column 'c1'.
```

Therefore, the `ACCEPT_ANY_SCHEMA` capability is added to `DorisTable` to implement the writing of partial column data.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
