### PR TITLE
[read](data-type) compatible with ip data type

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/RowBatch.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/RowBatch.java
@@ -282,18 +282,19 @@ public class RowBatch implements Serializable {
                         }
                         break;
                     case "IPV4":
-                        Preconditions.checkArgument(mt.equals(MinorType.UINT4) || mt.equals(MinorType.INT),
+                        Preconditions.checkArgument(mt.equals(MinorType.UINT4) || mt.equals(MinorType.INT) || mt.equals(MinorType.VARCHAR),
                                 typeMismatchMessage(colName, currentType, mt));
-                        BaseIntVector ipv4Vector;
-                        if (mt.equals(MinorType.INT)) {
-                            ipv4Vector = (IntVector) curFieldVector;
+
+                        if (mt.equals(MinorType.VARCHAR)) {
+                            VarCharVector vector = (VarCharVector) curFieldVector;
+                            for (int i = 0; i < rowCountInOneBatch; i++) {
+                                addValueToRow(i, vector.isNull(i) ? null : new String(vector.get(i)));
+                            }
                         } else {
-                            ipv4Vector = (UInt4Vector) curFieldVector;
-                        }
-                        for (int rowIndex = 0; rowIndex < rowCountInOneBatch; rowIndex++) {
-                            Object fieldValue = ipv4Vector.isNull(rowIndex) ? null :
-                                    IPUtils.convertLongToIPv4Address(ipv4Vector.getValueAsLong(rowIndex));
-                            addValueToRow(rowIndex, fieldValue);
+                            BaseIntVector vector = (mt.equals(MinorType.INT)) ? (IntVector) curFieldVector : (UInt4Vector) curFieldVector;
+                            for (int i = 0; i < rowCountInOneBatch; i++) {
+                                addValueToRow(i, vector.isNull(i) ? null : IPUtils.convertLongToIPv4Address(vector.getValueAsLong(i)));
+                            }
                         }
                         break;
                     case "FLOAT":
@@ -463,9 +464,15 @@ public class RowBatch implements Serializable {
                                 addValueToRow(rowIndex, null);
                                 break;
                             }
+                            // Compatible with IPv6  in Doris 2.1.3 and above.
                             String ipv6Str = new String(ipv6VarcharVector.get(rowIndex));
-                            String ipv6Address = IPUtils.fromBigInteger(new BigInteger(ipv6Str));
-                            addValueToRow(rowIndex, ipv6Address);
+                            if (ipv6Str.contains(":")){
+                                addValueToRow(rowIndex, ipv6Str);
+                            }else {
+                                String ipv6Address = IPUtils.fromBigInteger(new BigInteger(ipv6Str));
+                                addValueToRow(rowIndex, ipv6Address);
+                            }
+
                         }
                         break;
                     case "ARRAY":


### PR DESCRIPTION
# Proposed changes
Following PR https://github.com/apache/doris/pull/34042, Apache Doris 2.1.3 and newer versions now serialize IPv4/IPv6 types directly from parsed strings. This PR adapts our code to maintain compatibility with this change.
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
