### PR TITLE
[fix](connector)Fix the issue where 'case when' does not correspond to an error when the Spark predicate is pushed down(#282)

### DIFF
--- a/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisReaderITCase.scala
+++ b/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisReaderITCase.scala
@@ -455,10 +455,10 @@ class DorisReaderITCase(readMode: String, flightSqlPort: Int) extends AbstractCo
         |    (case when c5 > 10 then c2 else null end) as cc1,
         |    (case when c4 < 5 then c3 else null end) as cc2
         |   from test_source where c2 is not null
-        |) where !(cc1 is null and cc2 is null)
+        |) where !(cc1 is null and cc2 is null) order by id
         |""".stripMargin)
 
-    assert("List([3,null,0], [1,127,null], [2,null,-32768])".equals(resultData.collect().toList.toString()))
+    assert("List([1,127,null], [2,null,-32768], [3,null,0])".equals(resultData.collect().toList.toString()))
 
     session.stop()
 

--- a/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisReaderITCase.scala
+++ b/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisReaderITCase.scala
@@ -453,12 +453,12 @@ class DorisReaderITCase(readMode: String, flightSqlPort: Int) extends AbstractCo
         |   select
         |    id,
         |    (case when c5 > 10 then c2 else null end) as cc1,
-        |    (case when c10 < '2025-3-28' then c3 else null end) as cc2
+        |    (case when c4 < 5 then c3 else null end) as cc2
         |   from test_source where c2 is not null
         |) where !(cc1 is null and cc2 is null)
         |""".stripMargin)
 
-    assert("List([1,127,32767])".equals(resultData.collect().toList.toString()))
+    assert("List([3,null,0], [1,127,null], [2,null,-32768])".equals(resultData.collect().toList.toString()))
 
     session.stop()
 

--- a/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisReaderITCase.scala
+++ b/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisReaderITCase.scala
@@ -424,4 +424,43 @@ class DorisReaderITCase(readMode: String, flightSqlPort: Int) extends AbstractCo
     assert("List([3])".equals(likeFilter.toList.toString()))
     session.stop()
   }
+
+
+  @Test
+  def buildCaseWhenTest(): Unit = {
+    val sourceInitSql: Array[String] = ContainerUtils.parseFileContentSQL("container/ddl/read_all_type.sql")
+    ContainerUtils.executeSQLStatement(getDorisQueryConnection(DATABASE), LOG, sourceInitSql: _*)
+
+    val session = SparkSession.builder().master("local[*]").getOrCreate()
+
+    session.sql(
+      s"""
+         |CREATE TEMPORARY VIEW test_source
+         |USING doris
+         |OPTIONS(
+         | "table.identifier"="${DATABASE + "." + TABLE_READ_TBL_ALL_TYPES}",
+         | "fenodes"="${getFenodes}",
+         | "user"="${getDorisUsername}",
+         | "password"="${getDorisPassword}",
+         | "doris.read.mode"="${readMode}",
+         | "doris.read.arrow-flight-sql.port"="${flightSqlPort}"
+         |)
+         |""".stripMargin)
+
+    val resultData = session.sql(
+      """
+        |select * from (
+        |   select
+        |    id,
+        |    (case when c5 > 10 then c2 else null end) as cc1,
+        |    (case when c10 < '2025-3-28' then c3 else null end) as cc2
+        |   from test_source where c2 is not null
+        |) where !(cc1 is null and cc2 is null)
+        |""".stripMargin)
+
+    assert("List([1,127,32767])".equals(resultData.collect().toList.toString()))
+
+    session.stop()
+
+  }
 }

--- a/spark-doris-connector/spark-doris-connector-spark-3.3/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3.3/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
@@ -57,6 +57,21 @@ class V2ExpressionBuilder(inValueLengthLimit: Int) {
             case "<=" => s"`${build(e.children()(0))}` <= ${build(e.children()(1))}"
             case ">" => s"`${build(e.children()(0))}` > ${build(e.children()(1))}"
             case ">=" => s"`${build(e.children()(0))}` >= ${build(e.children()(1))}"
+            case "CASE_WHEN" =>
+              val fragment = new StringBuilder("CASE ")
+              val expressions = e.children()
+
+              for(i<- 0 until expressions.size - 1 by 2){
+                fragment.append(s" WHEN ${build(expressions(i))} THEN ${build(expressions(i+1))} ")
+              }
+
+              if (expressions.length % 2 != 0) {
+                val last = expressions(expressions.length - 1)
+                fragment.append(s" ELSE ${build(last)} ")
+              }
+              fragment.append(" END")
+
+              fragment.mkString
             case _ => null
           }
         }

--- a/spark-doris-connector/spark-doris-connector-spark-3.4/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3.4/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
@@ -55,6 +55,21 @@ class V2ExpressionBuilder(inValueLengthLimit: Int) {
             case "<=" => s"`${build(e.children()(0))}` <= ${build(e.children()(1))}"
             case ">" => s"`${build(e.children()(0))}` > ${build(e.children()(1))}"
             case ">=" => s"`${build(e.children()(0))}` >= ${build(e.children()(1))}"
+            case "CASE_WHEN" =>
+              val fragment = new StringBuilder("CASE ")
+              val expressions = e.children()
+
+              for(i<- 0 until expressions.size - 1 by 2){
+                fragment.append(s" WHEN ${build(expressions(i))} THEN ${build(expressions(i+1))} ")
+              }
+
+              if (expressions.length % 2 != 0) {
+                val last = expressions(expressions.length - 1)
+                fragment.append(s" ELSE ${build(last)} ")
+              }
+              fragment.append(" END")
+
+              fragment.mkString
             case _ => null
           }
         }

--- a/spark-doris-connector/spark-doris-connector-spark-3.5/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3.5/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
@@ -55,6 +55,21 @@ class V2ExpressionBuilder(inValueLengthLimit: Int) {
             case "<=" => s"`${build(e.children()(0))}` <= ${build(e.children()(1))}"
             case ">" => s"`${build(e.children()(0))}` > ${build(e.children()(1))}"
             case ">=" => s"`${build(e.children()(0))}` >= ${build(e.children()(1))}"
+            case "CASE_WHEN" =>
+              val fragment = new StringBuilder("CASE ")
+              val expressions = e.children()
+
+              for(i<- 0 until expressions.size - 1 by 2){
+                fragment.append(s" WHEN ${build(expressions(i))} THEN ${build(expressions(i+1))} ")
+              }
+
+              if (expressions.length % 2 != 0) {
+                val last = expressions(expressions.length - 1)
+                fragment.append(s" ELSE ${build(last)} ")
+              }
+              fragment.append(" END")
+
+              fragment.mkString
             case _ => null
           }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #282

## Problem Summary:

Fix the issue where 'case when' does not correspond to an error when the Spark predicate is pushed down.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
