### PR TITLE
change ControlThrowable from NonFatal to Fatal

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/exception/StreamLoadException.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/exception/StreamLoadException.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.spark.exception;
 
-public class StreamLoadException extends Exception {
+import scala.util.control.ControlThrowable;
+
+public class StreamLoadException extends Exception implements ControlThrowable {
     public StreamLoadException() {
         super();
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #205 

## Problem Summary:

Throw exception when commit unsuccessfully. And change the exception from NonFatal to Fatal exception to make spark application throw Fatal exception and make the job failed eventually.


## Checklist(Required)

1. Does it affect the original behavior: (Yes)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
