### PR TITLE
[fix](connector) Fixed the issue where the loading task got stuck when stream load ended unexpectedly 

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -465,7 +465,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
 
     private void writeTo(byte[] bytes) throws Exception {
         try {
-            output.write(bytes, 0, bytes.length);
+            output.write(bytes);
         } catch (Exception e) {
             if (unexpectedException != null) {
                 throw unexpectedException;

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -142,6 +142,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         if (createNewBatch) {
             createNewBatch = false;
             isStopped = false;
+            unexpectedException = null;
             if (autoRedirect) {
                 requestFuture = frontend.requestFrontends((frontEnd, httpClient) ->
                         buildReqAndExec(frontEnd.getHost(), frontEnd.getHttpPort(), httpClient));

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -174,11 +174,14 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
             StreamLoadResponse response;
             try {
                 response = requestFuture.get();
+                if (response == null) {
+                    throw new StreamLoadException("response is null");
+                }
             } catch (Exception e) {
                 if (unexpectedException != null) {
                     throw unexpectedException;
                 }
-                throw new RuntimeException("stream load failed", e);
+                throw new StreamLoadException("stream load stop failed", e);
             }
             return isTwoPhaseCommitEnabled ? String.valueOf(response.getTxnId()) : null;
         }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -162,6 +162,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     @Override
     public String stop() throws Exception {
         if (requestFuture != null) {
+            createNewBatch = true;
+            isFirstRecordOfBatch = true;
+            isStopped = true;
             // arrow format need to send all buffer data before stop
             if (!recordBuffer.isEmpty() && DataFormat.ARROW.equals(format)) {
                 List<R> rs = new LinkedList<>(recordBuffer);
@@ -171,9 +174,6 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
             output.close();
             logger.info("stream load stopped with {}", currentLabel != null ? currentLabel : "group commit");
             CloseableHttpResponse res = requestFuture.get();
-            createNewBatch = true;
-            isFirstRecordOfBatch = true;
-            isStopped = true;
             if (res.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
                 throw new StreamLoadException(
                         "stream load execute failed, status: " + res.getStatusLine().getStatusCode()

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -17,12 +17,6 @@
 
 package org.apache.doris.spark.client.write;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import org.apache.doris.spark.client.DorisBackendHttpClient;
 import org.apache.doris.spark.client.DorisFrontendClient;
 import org.apache.doris.spark.client.entity.Backend;
@@ -36,6 +30,10 @@ import org.apache.doris.spark.util.EscapeHandler;
 import org.apache.doris.spark.util.HttpUtils;
 import org.apache.doris.spark.util.URLs;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
@@ -51,6 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,56 +66,41 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> implements DorisCommitter {
 
-    protected final Logger logger = LoggerFactory.getLogger(this.getClass().getName().replaceAll("\\$", ""));
-
-    protected static final JsonMapper MAPPER = JsonMapper.builder().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).build();
-
+    protected static final JsonMapper MAPPER =
+            JsonMapper.builder().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).build();
     private static final String PARTIAL_COLUMNS = "partial_columns";
     private static final String GROUP_COMMIT = "group_commit";
-    private static final Set<String> VALID_GROUP_MODE = new HashSet<>(Arrays.asList("sync_mode", "async_mode", "off_mode"));
-
+    private static final Set<String> VALID_GROUP_MODE =
+            new HashSet<>(Arrays.asList("sync_mode", "async_mode", "off_mode"));
+    private static final int arrowBufferSize = 1000;
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass().getName().replaceAll("\\$", ""));
     protected final DorisConfig config;
-
     private final DorisFrontendClient frontend;
     private final DorisBackendHttpClient backendHttpClient;
-
     private final String database;
     private final String table;
-
     private final boolean autoRedirect;
-
     private final boolean isHttpsEnabled;
-
     private final boolean isTwoPhaseCommitEnabled;
-
     private final Map<String, String> properties;
-
     private final DataFormat format;
-
-    protected String columnSeparator;
-
-    private byte[] lineDelimiter;
-
     private final boolean isGzipCompressionEnabled;
-
-    private String groupCommit;
-
     private final boolean isPassThrough;
-
-    private PipedOutputStream output;
-
-    private boolean createNewBatch = true;
-
-    private boolean isFirstRecordOfBatch = true;
-
     private final List<R> recordBuffer = new LinkedList<>();
-
-    private static final int arrowBufferSize = 1000;
-
+    protected String columnSeparator;
+    private byte[] lineDelimiter;
+    private String groupCommit;
+    private PipedOutputStream output;
+    private boolean createNewBatch = true;
+    private boolean isFirstRecordOfBatch = true;
     private transient ExecutorService executor;
 
     private Future<CloseableHttpResponse> requestFuture = null;
     private volatile String currentLabel;
+
+    private boolean isStopped = false;
+
+    private Exception unexpectedException = null;
 
     public AbstractStreamLoadProcessor(DorisConfig config) throws Exception {
         super(config.getValue(DorisOptions.DORIS_SINK_BATCH_SIZE));
@@ -132,57 +117,82 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         // init stream load props
         this.isTwoPhaseCommitEnabled = config.getValue(DorisOptions.DORIS_SINK_ENABLE_2PC);
         this.format = DataFormat.valueOf(properties.getOrDefault("format", "csv").toUpperCase());
-        this.isGzipCompressionEnabled = properties.containsKey("compress_type") && "gzip".equals(properties.get("compress_type"));
+        this.isGzipCompressionEnabled =
+                properties.containsKey("compress_type") && "gzip".equals(properties.get("compress_type"));
         if (properties.containsKey(GROUP_COMMIT)) {
             String message = "";
-            if (isTwoPhaseCommitEnabled) message = "group commit does not support two-phase commit";
-            if (properties.containsKey(PARTIAL_COLUMNS) && "true".equalsIgnoreCase(properties.get(PARTIAL_COLUMNS)))
+            if (isTwoPhaseCommitEnabled) {
+                message = "group commit does not support two-phase commit";
+            }
+            if (properties.containsKey(PARTIAL_COLUMNS) && "true".equalsIgnoreCase(properties.get(PARTIAL_COLUMNS))) {
                 message = "group commit does not support partial column updates";
-            if (!VALID_GROUP_MODE.contains(properties.get(GROUP_COMMIT).toLowerCase()))
+            }
+            if (!VALID_GROUP_MODE.contains(properties.get(GROUP_COMMIT).toLowerCase())) {
                 message = "Unsupported group commit mode: " + properties.get(GROUP_COMMIT);
-            if (!message.isEmpty()) throw new IllegalArgumentException(message);
+            }
+            if (!message.isEmpty()) {
+                throw new IllegalArgumentException(message);
+            }
             groupCommit = properties.get(GROUP_COMMIT).toLowerCase();
         }
         this.isPassThrough = config.getValue(DorisOptions.DORIS_SINK_STREAMING_PASSTHROUGH);
     }
 
     public void load(R row) throws Exception {
+        if (unexpectedException != null) {
+            throw unexpectedException;
+        }
         if (createNewBatch) {
+            createNewBatch = false;
+            isStopped = false;
             if (autoRedirect) {
                 requestFuture = frontend.requestFrontends((frontEnd, httpClient) ->
-                        buildReqAndExec(frontEnd.getHost(), frontEnd.getHttpPort(), httpClient));
+                {
+                    try {
+                        return buildReqAndExec(frontEnd.getHost(), frontEnd.getHttpPort(), httpClient);
+                    } catch (OptionRequiredException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
             } else {
                 requestFuture = backendHttpClient.executeReq((backend, httpClient) ->
-                        buildReqAndExec(backend.getHost(), backend.getHttpPort(), httpClient));
+                {
+                    try {
+                        return buildReqAndExec(backend.getHost(), backend.getHttpPort(), httpClient);
+                    } catch (OptionRequiredException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
             }
-            createNewBatch = false;
         }
         if (isFirstRecordOfBatch) {
             isFirstRecordOfBatch = false;
-        } else if (lineDelimiter != null){
-            output.write(lineDelimiter);
+        } else if (lineDelimiter != null) {
+            writeTo(lineDelimiter);
         }
-        output.write(toFormat(row, format));
+        writeTo(toFormat(row, format));
         currentBatchCount++;
     }
 
     @Override
     public String stop() throws Exception {
         if (requestFuture != null) {
+            isStopped = true;
             createNewBatch = true;
             isFirstRecordOfBatch = true;
             // arrow format need to send all buffer data before stop
             if (!recordBuffer.isEmpty() && DataFormat.ARROW.equals(format)) {
                 List<R> rs = new LinkedList<>(recordBuffer);
                 recordBuffer.clear();
-                output.write(toArrowFormat(rs));
+                writeTo(toArrowFormat(rs));
             }
             output.close();
             logger.info("stream load stopped with {}", currentLabel != null ? currentLabel : "group commit");
             CloseableHttpResponse res = requestFuture.get();
             if (res.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-                throw new StreamLoadException("stream load execute failed, status: " + res.getStatusLine().getStatusCode()
-                        + ", msg: " + res.getStatusLine().getReasonPhrase());
+                throw new StreamLoadException(
+                        "stream load execute failed, status: " + res.getStatusLine().getStatusCode()
+                                + ", msg: " + res.getStatusLine().getReasonPhrase());
             }
             String resEntity = EntityUtils.toString(new BufferedHttpEntity(res.getEntity()));
             logger.info("stream load response: {}", resEntity);
@@ -211,8 +221,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                         .getReasonPhrase());
             } else {
                 String resEntity = EntityUtils.toString(new BufferedHttpEntity(response.getEntity()));
-                if(!checkTransResponse(resEntity)) {
-                    throw new RuntimeException("commit transaction failed, transaction: " + msg + ", resp: " + resEntity);
+                if (!checkTransResponse(resEntity)) {
+                    throw new RuntimeException(
+                            "commit transaction failed, transaction: " + msg + ", resp: " + resEntity);
                 } else {
                     this.logger.info("commit: {} response: {}", msg, resEntity);
                 }
@@ -256,8 +267,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                         .getReasonPhrase());
             } else {
                 String resEntity = EntityUtils.toString(new BufferedHttpEntity(response.getEntity()));
-                if(!checkTransResponse(resEntity)) {
-                    throw new RuntimeException("abort transaction failed, transaction: " + msg + ", resp: " + resEntity);
+                if (!checkTransResponse(resEntity)) {
+                    throw new RuntimeException(
+                            "abort transaction failed, transaction: " + msg + ", resp: " + resEntity);
                 } else {
                     this.logger.info("abort: {} response: {}", msg, resEntity);
                 }
@@ -271,11 +283,11 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         ObjectMapper objectMapper = new ObjectMapper();
         try {
             String status = objectMapper.readTree(resEntity).get("status").asText();
-                if ("Success".equalsIgnoreCase(status)) {
-                    return true;
-                }
+            if ("Success".equalsIgnoreCase(status)) {
+                return true;
+            }
         } catch (JsonProcessingException e) {
-            logger.warn("invalid json response: " +  resEntity, e);
+            logger.warn("invalid json response: " + resEntity, e);
         }
         return false;
     }
@@ -341,7 +353,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         if (config.contains(DorisOptions.DORIS_MAX_FILTER_RATIO)) {
             httpPut.setHeader("max_filter_ratio", config.getValue(DorisOptions.DORIS_MAX_FILTER_RATIO));
         }
-        if (isTwoPhaseCommitEnabled) httpPut.setHeader("two_phase_commit", "true");
+        if (isTwoPhaseCommitEnabled) {
+            httpPut.setHeader("two_phase_commit", "true");
+        }
 
         switch (format) {
             case CSV:
@@ -352,7 +366,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                 break;
             case JSON:
                 lineDelimiter = properties.getOrDefault("line_delimiter", "\n").getBytes(
-                    StandardCharsets.UTF_8);
+                        StandardCharsets.UTF_8);
                 properties.put("read_json_by_line", "true");
                 break;
             case ARROW:
@@ -384,14 +398,16 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
 
     protected abstract String generateStreamLoadLabel() throws OptionRequiredException;
 
-    private Future<CloseableHttpResponse> buildReqAndExec(String host, Integer port, CloseableHttpClient client) {
+    private Future<CloseableHttpResponse> buildReqAndExec(String host, Integer port, CloseableHttpClient client)
+            throws OptionRequiredException {
         HttpPut httpPut = new HttpPut(URLs.streamLoad(host, port, database, table, isHttpsEnabled));
         try {
             handleStreamLoadProperties(httpPut);
         } catch (OptionRequiredException e) {
             throw new RuntimeException("stream load handle properties failed", e);
         }
-        PipedInputStream pipedInputStream = new PipedInputStream(4096);
+        PipedInputStream pipedInputStream =
+                new PipedInputStream(config.getValue(DorisOptions.DORIS_SINK_NET_BUFFER_SIZE));
         try {
             output = new PipedOutputStream(pipedInputStream);
         } catch (IOException e) {
@@ -402,9 +418,32 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
             entity = new GzipCompressingEntity(entity);
         }
         httpPut.setEntity(entity);
+        Thread currentThread = Thread.currentThread();
 
-        logger.info("table {}.{} stream load started for {} on host {}:{}", database, table, currentLabel != null ? currentLabel : "group commit", host, port);
-        return getExecutors().submit(() -> client.execute(httpPut));
+        logger.info("table {}.{} stream load started for {} on host {}:{}", database, table,
+                currentLabel != null ? currentLabel : "group commit", host, port);
+        return getExecutors().submit(() -> {
+            CloseableHttpResponse response = client.execute(httpPut);
+            // stream load http request finished unexpectedly
+            if (!isStopped) {
+                if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                    unexpectedException = new StreamLoadException(
+                            "stream load failed, status: " + response.getStatusLine().getStatusCode()
+                                    + ", reason: " + response.getStatusLine().getReasonPhrase());
+                } else {
+                    StreamLoadResponse streamLoadResponse =
+                            MAPPER.readValue(EntityUtils.toString(response.getEntity()), StreamLoadResponse.class);
+                    if (!streamLoadResponse.isSuccess()) {
+                        unexpectedException = new StreamLoadException(
+                                "stream load end unexpectedly, txnId: " + streamLoadResponse.getTxnId()
+                                        + ", status: " + streamLoadResponse.getStatus()
+                                        + ", msg: " + streamLoadResponse.getMessage());
+                    }
+                }
+                currentThread.interrupt();
+            }
+            return response;
+        });
     }
 
     @Override
@@ -445,6 +484,18 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
             });
         }
         return executor;
+    }
+
+    private void writeTo(byte[] bytes) throws Exception {
+        try {
+            output.write(bytes);
+        } catch (Exception e) {
+            if (unexpectedException != null) {
+                throw unexpectedException;
+            } else {
+                throw e;
+            }
+        }
     }
 
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
@@ -65,7 +65,7 @@ public class DorisOptions {
 
     public static final ConfigOption<String> DORIS_WRITE_FIELDS = ConfigOptions.name("doris.write.fields").stringType().withoutDefaultValue().withDescription("");
 
-    public static final ConfigOption<Integer> DORIS_SINK_BATCH_SIZE = ConfigOptions.name("doris.sink.batch.size").intType().defaultValue(100000).withDescription("");
+    public static final ConfigOption<Integer> DORIS_SINK_BATCH_SIZE = ConfigOptions.name("doris.sink.batch.size").intType().defaultValue(500000).withDescription("");
 
     public static final ConfigOption<Integer> DORIS_SINK_MAX_RETRIES = ConfigOptions.name("doris.sink.max-retries").intType().defaultValue(0).withDescription("");
 
@@ -128,6 +128,8 @@ public class DorisOptions {
     public static final ConfigOption<Boolean> DORIS_READ_BITMAP_TO_STRING = ConfigOptions.name("doris.read.bitmap-to-string").booleanType().defaultValue(false).withDescription("");
 
     public static final ConfigOption<Boolean> DORIS_READ_BITMAP_TO_BASE64 = ConfigOptions.name("doris.read.bitmap-to-base64").booleanType().defaultValue(false).withDescription("");
+
+    public static final ConfigOption<Integer> DORIS_SINK_NET_BUFFER_SIZE = ConfigOptions.name("doris.sink.net.buffer.size").intType().defaultValue(1024 * 1024).withDescription("");
 
 
 }

--- a/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisWriterFailoverITCase.scala
+++ b/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisWriterFailoverITCase.scala
@@ -22,6 +22,7 @@ import org.apache.doris.spark.container.{AbstractContainerTestBase, ContainerUti
 import org.apache.doris.spark.rest.models.DataModel
 import org.apache.spark.SparkException
 import org.apache.spark.sql.SparkSession
+import org.hamcrest.{CoreMatchers, Description, Matcher}
 import org.junit.rules.ExpectedException
 import org.junit.{Before, Rule, Test}
 import org.slf4j.LoggerFactory
@@ -237,7 +238,6 @@ class DorisWriterFailoverITCase extends AbstractContainerTestBase {
         ("catalog", "uk")
       )).toDF("name", "address")
       thrown.expect(classOf[SparkException])
-      thrown.expectMessage("Only unique key merge on write support partial update")
       df.write.format("doris")
         .option("table.identifier", DATABASE + "." + TABLE_WRITE_TBL_FAIL_BEFORE_STOP)
         .option("fenodes", getFenodes)

--- a/spark-doris-connector/spark-doris-connector-spark-3-base/src/main/scala/org/apache/doris/spark/write/DorisDataWriter.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3-base/src/main/scala/org/apache/doris/spark/write/DorisDataWriter.scala
@@ -28,11 +28,9 @@ import org.apache.spark.sql.types.StructType
 import java.time.Duration
 import java.util.concurrent.locks.LockSupport
 import scala.collection.mutable
-import scala.util.{Failure, Random, Success}
+import scala.util.{Failure, Success}
 
 class DorisDataWriter(config: DorisConfig, schema: StructType, partitionId: Int, taskId: Long, epochId: Long = -1) extends DataWriter[InternalRow] with Logging {
-
-  private val batchSize = config.getValue(DorisOptions.DORIS_SINK_BATCH_SIZE)
 
   private val (writer: DorisWriter[InternalRow], committer: DorisCommitter) =
     config.getValue(DorisOptions.LOAD_MODE) match {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

If the stream load http request ends before a batch of data is sent for some reason, the writer thread will be stuck. If you get the thread stack through jstack, you will see the following situation:

```java
"stream-load-worker-0" #58 daemon prio=5 os_prio=31 tid=0x00000001150c9000 nid=0xaf03 waiting on condition [0x000000030479e000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x00000007bba4c428> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2044)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)

"Executor task launch worker for task 0.0 in stage 0.0 (TID 0)" #57 daemon prio=5 os_prio=31 tid=0x00000001606a5000 nid=0x5307 in Object.wait() [0x0000000304591000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at java.io.PipedInputStream.awaitSpace(PipedInputStream.java:273)
        at java.io.PipedInputStream.receive(PipedInputStream.java:231)
        - locked <0x00000007bb972cc8> (a java.io.PipedInputStream)
        at java.io.PipedOutputStream.write(PipedOutputStream.java:149)
        at java.io.OutputStream.write(OutputStream.java:75)
        at org.apache.doris.spark.client.write.AbstractStreamLoadProcessor.load(AbstractStreamLoadProcessor.java:165)
        at org.apache.doris.spark.write.DorisDataWriter.$anonfun$loadBatchWithRetries$1(DorisDataWriter.scala:110)
        at org.apache.doris.spark.write.DorisDataWriter$$Lambda$2433/1537409281.apply$mcV$sp(Unknown Source)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.util.Try$.apply(Try.scala:213)
        at org.apache.doris.spark.util.Retry$.exec(Retry.scala:34)
        at org.apache.doris.spark.write.DorisDataWriter.loadBatchWithRetries(DorisDataWriter.scala:111)
        at org.apache.doris.spark.write.DorisDataWriter.write(DorisDataWriter.scala:54)
        at org.apache.doris.spark.write.DorisDataWriter.write(DorisDataWriter.scala:33)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.write(WriteToDataSourceV2Exec.scala:493)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.$anonfun$run$1(WriteToDataSourceV2Exec.scala:448)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask$$Lambda$2429/584782873.apply(Unknown Source)
        at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1397)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.run(WriteToDataSourceV2Exec.scala:486)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.run$(WriteToDataSourceV2Exec.scala:425)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:491)
        at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.$anonfun$writeWithV2$2(WriteToDataSourceV2Exec.scala:388)
        at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec$$Lambda$2427/1767225268.apply(Unknown Source)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
        at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)
        at org.apache.spark.scheduler.Task.run(Task.scala:141)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:620)
        at org.apache.spark.executor.Executor$TaskRunner$$Lambda$2389/1439152090.apply(Unknown Source)
        at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
        at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:94)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:623)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

Since the http request has ended, the data written to the output stream buffer will not be read, so the main thread will be stuck here.
Therefore, a flag is added to indicate whether the batch import is stopped normally. If not and the http request has ended, the main thread will be interrupted and an exception will be thrown.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
