### PR TITLE
[BUG FIX]fix filter push issue with OR in SQL

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/DorisDialects.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/DorisDialects.scala
@@ -50,12 +50,12 @@ object DorisDialects {
       case And(left, right) =>
         val and = Seq(left, right).flatMap(compileFilter(_, inValueLengthLimit))
         if (and.size == 2) {
-          and.map(p => s"($p)").mkString(" AND ")
+          s"(${and.map(p => s"($p)").mkString(" AND ")})"
         } else null
       case Or(left, right) =>
         val or = Seq(left, right).flatMap(compileFilter(_, inValueLengthLimit))
         if (or.size == 2) {
-          or.map(p => s"($p)").mkString(" OR ")
+          s"(${or.map(p => s"($p)").mkString(" OR ")})"
         } else null
       case StringContains(attribute, value) => s"${quote(attribute)} LIKE '%$value%'"
       case Not(StringContains(attribute, value)) => s"${quote(attribute)} NOT LIKE '%$value%'"

--- a/spark-doris-connector/spark-doris-connector-base/src/test/scala/org/apache/doris/spark/util/DorisDialectsTest.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/scala/org/apache/doris/spark/util/DorisDialectsTest.scala
@@ -38,8 +38,10 @@ class DorisDialectsTest {
     Assert.assertEquals(DorisDialects.compileFilter(Not(In("c7", Array(10,11,12))), 10).get, "`c7` NOT IN (10,11,12)")
     Assert.assertEquals(DorisDialects.compileFilter(IsNull("c8"), 10).get, "`c8` IS NULL")
     Assert.assertEquals(DorisDialects.compileFilter(IsNotNull("c9"), 10).get, "`c9` IS NOT NULL")
-    Assert.assertEquals(DorisDialects.compileFilter(And(EqualTo("c10", 13), EqualTo("c11", 14)), 10).get, "(`c10` = 13) AND (`c11` = 14)")
-    Assert.assertEquals(DorisDialects.compileFilter(Or(EqualTo("c12", 15), EqualTo("c13", 16)), 10).get, "(`c12` = 15) OR (`c13` = 16)")
+    Assert.assertEquals(DorisDialects.compileFilter(And(EqualTo("c10", 13), EqualTo("c11", 14)), 10).get, "((`c10` = 13) AND (`c11` = 14))")
+    Assert.assertEquals(DorisDialects.compileFilter(Or(EqualTo("c12", 15), EqualTo("c13", 16)), 10).get, "((`c12` = 15) OR (`c13` = 16))")
+    Assert.assertEquals(DorisDialects.compileFilter(Or(Or(EqualTo("c12", 15), EqualTo("c13", 16)), GreaterThan("c14", 17)), 10).get,
+      "((((`c12` = 15) OR (`c13` = 16))) OR (`c14` > 17))")
     Assert.assertEquals(DorisDialects.compileFilter(StringContains("c14", "a"), 10).get, "`c14` LIKE '%a%'")
     Assert.assertEquals(DorisDialects.compileFilter(Not(StringContains("c15", "a")), 10).get, "`c15` NOT LIKE '%a%'")
     Assert.assertEquals(DorisDialects.compileFilter(StringEndsWith("c16", "a"), 10).get, "`c16` LIKE '%a'")


### PR DESCRIPTION
## Problem Summary:

fix push filter bugs:

Spark SQL Condition:
`
WHERE dt between '2025-03-01' AND '2025-05-30'
AND income_type not in (4, 26) AND NOT(dt < '2025-04-01' AND data_type in (2, -2) AND income_type = 1)
`

WRONG Condition Pushed to Doris [BUGS]:

`
WHERE `dt` IS NOT NULL AND `dt` >= '2025-03-01 00:00:00.0' AND `dt` <= '2025-05-30 00:00:00.0' AND `income_type` NOT IN (4,26) AND ((`dt` >= '2025-04-01 00:00:00.0') OR (`data_type` NOT IN (2,-2))) OR (`income_type` != 1)
`
Because of the wrong condition "OR (`income_type` != 1)", a full table scan operation was caused.

