### PR TITLE
[Fix] Fixed the problem that retry may get stuck when fe hangs up

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/DorisBackendHttpClient.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/DorisBackendHttpClient.java
@@ -18,6 +18,7 @@
 package org.apache.doris.spark.client;
 
 import org.apache.doris.spark.client.entity.Backend;
+import org.apache.doris.spark.util.HttpUtil;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
@@ -46,14 +47,21 @@ public class DorisBackendHttpClient implements Serializable {
         Exception ex = null;
         for (Backend backend : backends) {
             try {
-                return reqFunc.apply(backend, httpClient);
+                if(HttpUtil.tryHttpConnection(backend.hostHttpPortString())){
+                    return reqFunc.apply(backend, httpClient);
+                }
             } catch (Exception e) {
                 log.warn("Failed to execute request on backend: {}:{}", backend.getHost(), backend.getHttpPort(), e);
                 ex = e;
             }
         }
+
+        if (ex == null) {
+            ex = new Exception("All backends failed to execute request.");
+        }
         throw ex;
     }
+
 
     public void close() {
         if (httpClient != null) {

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/DorisFrontendClient.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/DorisFrontendClient.java
@@ -26,6 +26,7 @@ import org.apache.doris.spark.exception.OptionRequiredException;
 import org.apache.doris.spark.rest.models.Field;
 import org.apache.doris.spark.rest.models.QueryPlan;
 import org.apache.doris.spark.rest.models.Schema;
+import org.apache.doris.spark.util.HttpUtil;
 import org.apache.doris.spark.util.HttpUtils;
 import org.apache.doris.spark.util.URLs;
 
@@ -157,13 +158,18 @@ public class DorisFrontendClient implements Serializable {
         Exception ex = null;
         for (Frontend frontEnd : frontEnds) {
             try {
-                return reqFunc.apply(frontEnd, httpClient);
+                if(HttpUtil.tryHttpConnection(frontEnd.hostHttpPortString())){
+                    return reqFunc.apply(frontEnd, httpClient);
+                }
             } catch (Exception e) {
                 LOG.warn("fe http request on {} failed, err: {}", frontEnd.hostHttpPortString(), e.getMessage());
                 ex = e;
             }
         }
-        throw ex;
+        if (ex == null) {
+            ex = new Exception("All frontends failed to execute request.");
+        }
+        throw new DorisException(ex);
     }
 
     public <T> T queryFrontends(Function<Connection, T> function) throws Exception {

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/Backend.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/Backend.java
@@ -77,4 +77,8 @@ public class Backend implements Serializable {
         return String.format("%s:%d", host, rpcPort);
     }
 
+    public String hostHttpPortString() {
+        return host + ":" + httpPort;
+    }
+
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -90,8 +90,6 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     private byte[] lineDelimiter;
     private String groupCommit;
     private PipedOutputStream output;
-    private boolean createNewBatch = true;
-    private boolean isFirstRecordOfBatch = true;
     private transient ExecutorService executor;
 
     private Future<StreamLoadResponse> requestFuture = null;
@@ -426,6 +424,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                 logger.error("stream load exception", e);
                 unexpectedException = e;
                 currentThread.interrupt();
+                throw e;
             }
             return streamLoadResponse;
         });

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/DorisWriter.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/DorisWriter.java
@@ -25,8 +25,9 @@ import java.io.Serializable;
 public abstract class DorisWriter<R> implements Serializable {
 
     protected int batchSize;
-
     protected int currentBatchCount = 0;
+    protected boolean createNewBatch = true;
+    protected boolean isFirstRecordOfBatch = true;
 
     public DorisWriter(int batchSize) {
         if (batchSize <= 0) {
@@ -50,7 +51,9 @@ public abstract class DorisWriter<R> implements Serializable {
     }
 
     public void resetBatchCount() {
-        currentBatchCount = 0;
+        this.currentBatchCount = 0;
+        this.createNewBatch = true;
+        this.isFirstRecordOfBatch = true;
     }
 
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/util/HttpUtil.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/util/HttpUtil.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class HttpUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(HttpUtil.class);
+
+    public static boolean tryHttpConnection(String host) {
+        try {
+            LOG.debug("try to connect host {}", host);
+            host = "http://" + host;
+            URL url = new URL(host);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setConnectTimeout(60000);
+            connection.setReadTimeout(60000);
+            int responseCode = connection.getResponseCode();
+            String responseMessage = connection.getResponseMessage();
+            connection.disconnect();
+            if (responseCode < 500) {
+                // code greater than 500 means a server-side exception.
+                return true;
+            }
+            LOG.warn(
+                    "Failed to connect host {}, responseCode={}, msg={}",
+                    host,
+                    responseCode,
+                    responseMessage);
+            return false;
+        } catch (Exception ex) {
+            LOG.warn("Failed to connect to host:{}, cause {}", host, ex.getMessage());
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
# Proposed changes

If doris.sink.max-retries is configured, there may be a situation where the spark executor gets stuck when fe crashes.
As shown in the following jstack, the main thread is continuously writing to the pipe, and the streamload thread that consumes the pipe has exited. When the pipe is full, it will get stuck.

```java
"stream-load-worker-0" #55 daemon prio=5 os_prio=31 tid=0x0000000143b9c800 nid=0xfd03 waiting on condition [0x0000000177b56000]
   java.lang.Thread.State: WAITING (parking)
        at sun.misc.Unsafe.park(Native Method)
        - parking to wait for  <0x0000000776ea8260> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2044)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1074)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1134)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)

"Executor task launch worker for task 0.0 in stage 0.0 (TID 0)" #54 daemon prio=5 os_prio=31 tid=0x0000000125c6b000 nid=0x4307 in Object.wait() [0x0000000177949000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at java.io.PipedInputStream.awaitSpace(PipedInputStream.java:273)
        at java.io.PipedInputStream.receive(PipedInputStream.java:231)
        - locked <0x0000000776e999e8> (a java.io.PipedInputStream)
        at java.io.PipedOutputStream.write(PipedOutputStream.java:149)
        at java.io.OutputStream.write(OutputStream.java:75)
        at org.apache.doris.spark.client.write.AbstractStreamLoadProcessor.writeTo(AbstractStreamLoadProcessor.java:475)
        at org.apache.doris.spark.client.write.AbstractStreamLoadProcessor.load(AbstractStreamLoadProcessor.java:150)
        at org.apache.doris.spark.write.DorisDataWriter.$anonfun$loadBatchWithRetries$1(DorisDataWriter.scala:110)
        at org.apache.doris.spark.write.DorisDataWriter$$Lambda$2334/1771533597.apply$mcV$sp(Unknown Source)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.util.Try$.apply(Try.scala:213)
        at org.apache.doris.spark.util.Retry$.exec(Retry.scala:34)
        at org.apache.doris.spark.write.DorisDataWriter.loadBatchWithRetries(DorisDataWriter.scala:111)
        at org.apache.doris.spark.write.DorisDataWriter.write(DorisDataWriter.scala:54)
        at org.apache.doris.spark.write.DorisDataWriter.write(DorisDataWriter.scala:33)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.write(WriteToDataSourceV2Exec.scala:493)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.$anonfun$run$1(WriteToDataSourceV2Exec.scala:448)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask$$Lambda$2330/1720488.apply(Unknown Source)
        at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1397)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.run(WriteToDataSourceV2Exec.scala:486)
        at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.run$(WriteToDataSourceV2Exec.scala:425)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:491)
        at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.$anonfun$writeWithV2$2(WriteToDataSourceV2Exec.scala:388)
        at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec$$Lambda$2327/1706417075.apply(Unknown Source)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
        at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:161)
```


## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
