### PR TITLE
[Improve] add schema less option

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
@@ -69,6 +69,8 @@ public class DorisOptions {
 
     public static final ConfigOption<String> DORIS_WRITE_FIELDS = ConfigOptions.name("doris.write.fields").stringType().withoutDefaultValue().withDescription("");
 
+    public static final ConfigOption<Boolean> DORIS_WRITE_SCHEMA_LESS = ConfigOptions.name("doris.write.schemaless").booleanType().defaultValue(false).withDescription("");
+
     public static final ConfigOption<Integer> DORIS_SINK_BATCH_SIZE = ConfigOptions.name("doris.sink.batch.size").intType().defaultValue(500000).withDescription("");
 
     public static final ConfigOption<Integer> DORIS_SINK_MAX_RETRIES = ConfigOptions.name("doris.sink.max-retries").intType().defaultValue(0).withDescription("");

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/util/LoadBalanceListTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/util/LoadBalanceListTest.java
@@ -41,7 +41,7 @@ public class LoadBalanceListTest {
 				if (index++ == 0) {
 					testHeadSet.add(server);
 				}
-				System.out.println(server);
+				// System.out.println(server);
 			}
 			if (i % serverList.size() == 0) {
 				Assert.assertTrue(testList.equals(Arrays.asList("server1", "server2", "server3")));
@@ -55,7 +55,7 @@ public class LoadBalanceListTest {
 				Assert.assertTrue(testList.equals(Arrays.asList("server3", "server1", "server2")));
 			}
 
-			System.out.println("---------");
+			// System.out.println("---------");
 			Assert.assertTrue(testList.size() == serverList.size());
 		}
 		Assert.assertTrue(testHeadSet.size() == serverList.size());
@@ -80,9 +80,9 @@ public class LoadBalanceListTest {
 				if (++index > loadBalanceList.getList().size() - failedSet.size()) {
 					Assert.assertTrue(failedSet.contains(server));
 				}
-				System.out.println(server);
+				// System.out.println(server);
 			}
-			System.out.println("---------");
+			// System.out.println("---------");
 			Assert.assertTrue(serverSet.size() == serverList.size());
 		}
 	}

--- a/spark-doris-connector/spark-doris-connector-spark-3-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableBase.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-3-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableBase.scala
@@ -51,7 +51,9 @@ abstract class DorisTableBase(identifier: Identifier, config: DorisConfig, schem
       STREAMING_WRITE,
       TRUNCATE)
     val properties = config.getSinkProperties
-    if (properties.containsKey(DorisOptions.PARTIAL_COLUMNS) && "true".equalsIgnoreCase(properties.get(DorisOptions.PARTIAL_COLUMNS))) {
+    val partialColumnsEnabled = properties.containsKey(DorisOptions.PARTIAL_COLUMNS) && "true".equalsIgnoreCase(properties.get(DorisOptions.PARTIAL_COLUMNS))
+    val schemaLessEnabled = config.getValue(DorisOptions.DORIS_WRITE_SCHEMA_LESS)
+    if (partialColumnsEnabled || schemaLessEnabled) {
       capabilities += ACCEPT_ANY_SCHEMA
     }
     capabilities.asJava


### PR DESCRIPTION
# Proposed changes

When Spark is processing, if the number of upstream and downstream fields does not match, an error will be reported during SparkSQL verification. Adding the switch `doris.write.schemaless` solves this problem.

```
org.apache.spark.sql.AnalysisException: [INCOMPATIBLE_DATA_FOR_TABLE.CANNOT_FIND_DATA] Cannot write incompatible data for the table `example_db`.`table_schema_less`: Cannot find data for the output column `username`.

	at org.apache.spark.sql.errors.QueryCompilationErrors$.incompatibleDataToTableCannotFindDataError(QueryCompilationErrors.scala:2136)
	at org.apache.spark.sql.catalyst.analysis.TableOutputResolver$.$anonfun$reorderColumnsByName$1(TableOutputResolver.scala:191)
	at scala.collection.immutable.List.flatMap(List.scala:366)
	at org.apache.spark.sql.catalyst.analysis.TableOutputResolver$.reorderColumnsByName(TableOutputResolver.scala:180)
	at org.apache.spark.sql.catalyst.analysis.TableOutputResolver$.resolveOutputColumns(TableOutputResolver.scala:66)
	at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveOutputRelation$$anonfun$apply$50.applyOrElse(Analyzer.scala:3347)
	at org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveOutputRelation$$anonfun$apply$50.applyOrElse(Analyzer.scala:3343)
	at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.$anonfun$resolveOperatorsDownWithPruning$2(AnalysisHelper.scala:170)
	at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(origin.scala:76)
```

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
