### PR TITLE
[improve] Supports http request use utf8 charset

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
@@ -144,5 +144,7 @@ public class DorisOptions {
 
     public static final ConfigOption<Integer> DORIS_SINK_NET_BUFFER_SIZE = ConfigOptions.name("doris.sink.net.buffer.size").intType().defaultValue(1024 * 1024).withDescription("");
 
+    public static final ConfigOption<Boolean> DORIS_SINK_HTTP_UTF8_CHARSET = ConfigOptions.name("doris.sink.http-utf8-charset").booleanType().defaultValue(false).withDescription("");
+
 
 }

--- a/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisWriterITCase.scala
+++ b/spark-doris-connector/spark-doris-connector-it/src/test/java/org/apache/doris/spark/sql/DorisWriterITCase.scala
@@ -44,6 +44,7 @@ class DorisWriterITCase extends AbstractContainerTestBase {
   val TABLE_JSON_TBL_OVERWRITE: String = "tbl_json_tbl_overwrite"
   val TABLE_JSON_TBL_ARROW: String = "tbl_json_tbl_arrow"
   val TABLE_BITMAP_TBL: String = "tbl_write_tbl_bitmap"
+  val TABLE_UNICODE_COL: String = "tbl_unicode_col"
 
   @Test
   @throws[Exception]
@@ -413,4 +414,51 @@ class DorisWriterITCase extends AbstractContainerTestBase {
     LOG.info("Checking DorisWriterITCase result. testName={}, actual={}, expected={}", testName, actual, expected)
     assertEqualsInAnyOrder(expected.toList.asJava, actual.toList.asJava)
   }
+
+  @Test
+  def testWriteUnicodeColumn(): Unit = {
+    val createDb = String.format("CREATE DATABASE IF NOT EXISTS %s", DATABASE)
+    val targetInitSql: Array[String] = ContainerUtils.parseFileContentSQL("container/ddl/write_unicode_col.sql")
+    ContainerUtils.executeSQLStatement(getDorisQueryConnection, LOG, Array(createDb): _*)
+    val connection = getDorisQueryConnection(DATABASE)
+    ContainerUtils.executeSQLStatement(connection, LOG, targetInitSql: _*)
+
+    val session = SparkSession.builder().master("local[*]").getOrCreate()
+    try {
+      val df = session.createDataFrame(Seq(
+        (1, "243"),
+        (2, "1"),
+        (3, "287667876573")
+      )).toDF("序号", "内容")
+      df.createTempView("mock_source")
+      session.sql(
+        s"""
+           |CREATE TEMPORARY VIEW test_sink
+           |USING doris
+           |OPTIONS(
+           | "table.identifier"="${DATABASE + "." + TABLE_UNICODE_COL}",
+           | "fenodes"="${getFenodes}",
+           | "user"="${getDorisUsername}",
+           | "password"="${getDorisPassword}",
+           | "doris.sink.http-utf8-charset"="true"
+           |)
+           |""".stripMargin)
+      session.sql(
+        """
+          |insert into test_sink select `序号`,`内容` from mock_source
+          |""".stripMargin)
+
+      Thread.sleep(10000)
+      val actual = ContainerUtils.executeSQLStatement(
+        connection,
+        LOG,
+        String.format("select `序号`,`内容` from %s.%s", DATABASE, TABLE_UNICODE_COL),
+        2)
+      val expected = util.Arrays.asList("1,243", "2,1", "3,287667876573");
+      checkResultInAnyOrder("testWriteUnicodeColumn", expected.toArray, actual.toArray)
+    } finally {
+      session.stop()
+    }
+  }
+
 }

--- a/spark-doris-connector/spark-doris-connector-it/src/test/resources/container/ddl/write_unicode_col.sql
+++ b/spark-doris-connector/spark-doris-connector-it/src/test/resources/container/ddl/write_unicode_col.sql
@@ -1,0 +1,11 @@
+SET enable_unicode_name_support = true;
+DROP TABLE IF EXISTS `tbl_unicode_col`;
+CREATE TABLE `tbl_unicode_col` (
+  `序号` int NULL,
+  `内容` text NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`序号`)
+DISTRIBUTED BY HASH(`序号`) BUCKETS 1
+PROPERTIES (
+"replication_allocation" = "tag.location.default: 1"
+);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

When writing column names containing Chinese or other Unicode characters,  stream load will return the following exception information：
```json
{
    "TxnId": 2060,
    "Label": "spark-doris-0-0-0-1763547930966",
    "Comment": "",
    "TwoPhaseCommit": "false",
    "Status": "Fail",
    "Message": "[ANALYSIS_ERROR]TStatus: errCode = 2, detailMessage = Duplicate column: ??",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 0,
    "LoadTimeMs": 0,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 1,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 0,
    "ReceiveDataTimeMs": 0,
    "CommitAndPublishTimeMs": 0
}
```
You can now set `doris.sink.http-utf8-charset` to `true` to configure the HTTP client to use the UTF-8 character set, allowing Unicode characters to be included in the header.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
