### PR TITLE
[Feature] Support Spark 4.0

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -73,3 +73,25 @@ jobs:
     - name: Build spark load
       run: |
         cd spark-load && mvn clean package ${MVN_OPT} -Pspark3,scala_2.12
+
+  build-extension-spark4:
+    name: "Build Extensions (Spark 4.x)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Spark 4.x requires JDK 17 and Scala 2.13, so it builds in a separate job.
+    - name: Setup java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '17'
+        cache: 'maven'
+
+    - name: Build spark connector 4.0
+      run: |
+        cd spark-doris-connector && mvn clean install ${MVN_OPT} -Pspark-4.0 -pl spark-doris-connector-spark-4.0 -am

--- a/.github/workflows/run-e2ecase.yml
+++ b/.github/workflows/run-e2ecase.yml
@@ -61,3 +61,24 @@ jobs:
     - name: Run E2ECases for spark 3.5
       run: |
         cd spark-doris-connector && mvn clean test -Pspark-3-it,spark-3.5 -pl spark-doris-connector-it -am -DfailIfNoTests=false -Dtest="*E2ECase" -Dimage="apache/doris:doris-all-in-one-2.1.0"
+
+  run-e2ecase-spark4:
+    name: "Run E2ECases (Spark 4.x)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    # Spark 4.x requires JDK 17.
+    - name: Setup java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Run E2ECases for spark 4.0
+      run: |
+        cd spark-doris-connector && mvn clean test -Pspark-4-it,spark-4.0 -pl spark-doris-connector-it -am -DfailIfNoTests=false -Dtest="*E2ECase" -Dimage="apache/doris:doris-all-in-one-2.1.0"

--- a/.github/workflows/run-itcase.yml
+++ b/.github/workflows/run-itcase.yml
@@ -62,3 +62,24 @@ jobs:
       run: |
         cd spark-doris-connector && mvn clean test -Pspark-3-it,spark-3.5 -pl spark-doris-connector-it -am -DfailIfNoTests=false -Dtest="*ITCase" -Dimage="apache/doris:doris-all-in-one-2.1.0"
 
+  run-itcase-spark4:
+    name: "Run ITCases (Spark 4.x)"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    # Spark 4.x requires JDK 17.
+    - name: Setup java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '17'
+
+    - name: Run ITCases for spark 4.0
+      run: |
+        cd spark-doris-connector && mvn clean test -Pspark-4-it,spark-4.0 -pl spark-doris-connector-it -am -DfailIfNoTests=false -Dtest="*ITCase" -Dimage="apache/doris:doris-all-in-one-2.1.0"
+

--- a/spark-doris-connector/build.sh
+++ b/spark-doris-connector/build.sh
@@ -122,8 +122,8 @@ if [[ -f ${DORIS_HOME}/custom_env.sh ]]; then
 fi
 
 selectScala() {
-  echo 'Spark-Doris-Connector supports Scala 2.11 and 2.12. Which version do you need ?'
-  select scala in "2.11" "2.12"
+  echo 'Spark-Doris-Connector supports Scala 2.11, 2.12 and 2.13. Which version do you need ?'
+  select scala in "2.11" "2.12" "2.13"
   do
     case $scala in
       "2.11")
@@ -131,6 +131,9 @@ selectScala() {
         ;;
       "2.12")
         return 2
+        ;;
+      "2.13")
+        return 3
         ;;
       *)
         echo "invalid selected, exit.."
@@ -142,7 +145,7 @@ selectScala() {
 
 selectSpark() {
   echo 'Spark-Doris-Connector supports multiple versions of spark. Which version do you need ?'
-  select spark in "2.4" "3.1" "3.2" "3.3" "3.4" "3.5"  "other"
+  select spark in "2.4" "3.1" "3.2" "3.3" "3.4" "3.5" "4.0" "other"
   do
     case $spark in
       "2.4")
@@ -163,8 +166,11 @@ selectSpark() {
       "3.5")
         return 6
         ;;
-      "other")
+      "4.0")
         return 7
+        ;;
+      "other")
+        return 8
         ;;
     esac
   done
@@ -177,6 +183,8 @@ if [ ${ScalaVer} -eq 1 ]; then
     SCALA_VERSION="2.11.12"
 elif [ ${ScalaVer} -eq 2 ]; then
     SCALA_VERSION="2.12.18"
+elif [ ${ScalaVer} -eq 3 ]; then
+    SCALA_VERSION="2.13.16"
 fi
 
 
@@ -196,6 +204,8 @@ elif [ ${SparkVer} -eq 5 ]; then
 elif [ ${SparkVer} -eq 6 ]; then
     SPARK_VERSION="3.5.3"
 elif [ ${SparkVer} -eq 7 ]; then
+    SPARK_VERSION="4.0.0"
+elif [ ${SparkVer} -eq 8 ]; then
     # shellcheck disable=SC2162
     read -p 'Which spark version do you need? please input
     :' ver
@@ -204,6 +214,22 @@ fi
 
 if [[ $SPARK_VERSION =~ ^3.* && $SCALA_VERSION == "2.11.12" ]]; then
   echo_r "Spark 3.x is not compatible with scala 2.11, will exit."
+  exit 1
+fi
+
+if [[ $SPARK_VERSION =~ ^4.* && $SCALA_VERSION != "2.13.16" ]]; then
+  echo_r "Spark 4.x requires scala 2.13, will exit."
+  exit 1
+fi
+
+if [[ ! $SPARK_VERSION =~ ^4.* && $SCALA_VERSION == "2.13.16" ]]; then
+  echo_r "Scala 2.13 is only supported with Spark 4.x, will exit."
+  exit 1
+fi
+
+# Spark 4.x requires JDK 17. JAVA_VER is the class-file major version from env.sh (52=JDK8, 61=JDK17).
+if [[ $SPARK_VERSION =~ ^4.* && ${JAVA_VER:-0} -lt 61 ]]; then
+  echo_r "Spark 4.x requires JDK 17 or later, will exit."
   exit 1
 fi
 
@@ -218,7 +244,7 @@ echo_g " scala version: ${SCALA_VERSION}, major version: ${SCALA_MAJOR_VERSION}"
 echo_g " spark version: ${SPARK_VERSION}, major version: ${SPARK_MAJOR_VERSION}"
 echo_g " build starting..."
 
-if [[ $SPARK_VERSION =~ ^3.* ]]; then
+if [[ $SPARK_VERSION =~ ^3.* || $SPARK_VERSION =~ ^4.* ]]; then
   profile_name="spark-${SPARK_MAJOR_VERSION}"
   module_suffix=${SPARK_MAJOR_VERSION}
 else

--- a/spark-doris-connector/pom.xml
+++ b/spark-doris-connector/pom.xml
@@ -49,6 +49,8 @@
         <module>spark-doris-connector-spark-3.3</module>
         <module>spark-doris-connector-spark-3.4</module>
         <module>spark-doris-connector-spark-3.5</module>
+        <module>spark-doris-connector-spark-4-base</module>
+        <module>spark-doris-connector-spark-4.0</module>
     </modules>
 
     <scm>
@@ -86,6 +88,9 @@
         <scala.major.version>2.11</scala.major.version>
         <libthrift.version>0.16.0</libthrift.version>
         <arrow.version>15.0.2</arrow.version>
+        <adbc.version>0.14.0</adbc.version>
+        <grpc.version>1.60.0</grpc.version>
+        <protobuf.version>3.22.3</protobuf.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>github</project.scm.id>
         <netty.version>4.1.110.Final</netty.version>
@@ -137,6 +142,16 @@
             <dependency>
                 <groupId>org.apache.doris</groupId>
                 <artifactId>spark-doris-connector-spark-3.5</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.doris</groupId>
+                <artifactId>spark-doris-connector-spark-4-base</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.doris</groupId>
+                <artifactId>spark-doris-connector-spark-4.0</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -233,7 +248,7 @@
             <dependency>
                 <groupId>org.apache.arrow.adbc</groupId>
                 <artifactId>adbc-driver-flight-sql</artifactId>
-                <version>0.14.0</version>
+                <version>${adbc.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.arrow</groupId>
@@ -273,7 +288,7 @@
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty</artifactId>
-                <version>1.60.0</version>
+                <version>${grpc.version}</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>netty-codec-http2</artifactId>
@@ -313,7 +328,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.22.3</version>
+                <version>${protobuf.version}</version>
             </dependency>
 
             <dependency>
@@ -877,6 +892,24 @@
                 <spark.major.version>3.5</spark.major.version>
                 <scala.version>2.12.18</scala.version>
                 <scala.major.version>2.12</scala.major.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark-4.0</id>
+            <properties>
+                <spark.version>4.0.0</spark.version>
+                <spark.major.version>4.0</spark.major.version>
+                <scala.version>2.13.16</scala.version>
+                <scala.major.version>2.13</scala.major.version>
+                <!-- Match Spark 4's Arrow so the connector and Spark agree on one Arrow on the
+                     (unshaded) integration-test classpath; bump adbc/flight in lockstep. -->
+                <arrow.version>18.1.0</arrow.version>
+                <adbc.version>0.18.0</adbc.version>
+                <grpc.version>1.65.0</grpc.version>
+                <protobuf.version>3.25.1</protobuf.version>
+                <!-- Spark 4 on JDK 17 needs these module opens (Arrow off-heap, Spark date/time,
+                     Catalyst codegen, etc.) — mirrors Spark's own JavaModuleOptions. -->
+                <argLine>-Xmx512m --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED</argLine>
             </properties>
         </profile>
     </profiles>

--- a/spark-doris-connector/spark-doris-connector-base/pom.xml
+++ b/spark-doris-connector/spark-doris-connector-base/pom.xml
@@ -103,6 +103,15 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Pin arrow-memory-core to the connector's Arrow version so the test classpath stays
+             internally consistent. Spark 4.x ships a newer Arrow (provided), which otherwise
+             leaks a mismatched arrow-memory-core and breaks the allocation-manager lookup. -->
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-core</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.arrow.adbc</groupId>
             <artifactId>adbc-driver-flight-sql</artifactId>

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/StreamLoadResponse.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/StreamLoadResponse.java
@@ -93,6 +93,14 @@ public class StreamLoadResponse {
         return Status;
     }
 
+    /**
+     * When {@link #getStatus()} is "Label Already Exists", the state of the load that already used
+     * the label: "FINISHED" (committed/visible), "PRECOMMITTED", or "RUNNING" (still in flight).
+     */
+    public String getExistingJobStatus() {
+        return ExistingJobStatus;
+    }
+
     public String getMessage() {
         return Message;
     }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -93,7 +93,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     private transient ExecutorService executor;
 
     private Future<StreamLoadResponse> requestFuture = null;
-    private volatile String currentLabel;
+    // Owns the stream-load label across batches; reuses the label on a retry so the backend can
+    // deduplicate a batch that already committed (exactly-once on retry).
+    private final StreamLoadLabelManager labelManager;
     private Exception unexpectedException = null;
 
     public AbstractStreamLoadProcessor(DorisConfig config) throws Exception {
@@ -110,6 +112,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         this.properties = config.getSinkProperties();
         // init stream load props
         this.isTwoPhaseCommitEnabled = config.getValue(DorisOptions.DORIS_SINK_ENABLE_2PC);
+        this.labelManager = new StreamLoadLabelManager(isTwoPhaseCommitEnabled);
         this.format = DataFormat.valueOf(properties.getOrDefault("format", "csv").toUpperCase());
         // enable gzip compression by default for non-arrow formats
         if (!DataFormat.ARROW.equals(format)) {
@@ -168,7 +171,8 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                 writeTo(toArrowFormat(rs));
             }
             output.close();
-            logger.info("stream load stopped with {}", currentLabel != null ? currentLabel : "group commit");
+            logger.info("stream load stopped with {}",
+                    labelManager.currentLabel() != null ? labelManager.currentLabel() : "group commit");
 
             StreamLoadResponse response;
             try {
@@ -177,11 +181,15 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                     throw new StreamLoadException("response is null");
                 }
             } catch (Exception e) {
+                // Batch failed: keep the current label so the retry reuses it (dedup-safe).
+                labelManager.onBatchFailed();
                 if (unexpectedException != null) {
                     throw unexpectedException;
                 }
                 throw new StreamLoadException("stream load stop failed", e);
             }
+            // Batch committed: the next batch must use a fresh label.
+            labelManager.onBatchCommitted();
             return isTwoPhaseCommitEnabled ? String.valueOf(response.getTxnId()) : null;
         }
         return null;
@@ -326,8 +334,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     private void handleStreamLoadProperties(HttpPut httpPut) throws OptionRequiredException {
         addCommonHeaders(httpPut);
         if (groupCommit == null || groupCommit.equals("off_mode")) {
-            currentLabel = generateStreamLoadLabel();
-            httpPut.setHeader("label", currentLabel);
+            // Reuse the previous label when retrying a failed batch so the backend can dedup it;
+            // otherwise mint a fresh label for a new batch.
+            httpPut.setHeader("label", labelManager.labelForNextBatch(this::generateStreamLoadLabel));
         }
         String writeFields = getWriteFields();
         httpPut.setHeader("columns", writeFields);
@@ -398,9 +407,11 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         }
         httpPut.setEntity(entity);
         Thread currentThread = Thread.currentThread();
+        // Captured for the async task: whether this batch reuses a prior (failed) batch's label.
+        final boolean labelReused = labelManager.isReusingLabel();
 
         logger.info("table {}.{} stream load started for {} on host {}:{}", database, table,
-                currentLabel != null ? currentLabel : "group commit", host, port);
+                labelManager.currentLabel() != null ? labelManager.currentLabel() : "group commit", host, port);
         return getExecutors().submit(() -> {
             StreamLoadResponse streamLoadResponse = null;
             try (CloseableHttpResponse response = client.execute(httpPut)) {
@@ -418,10 +429,18 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                         || streamLoadResponse.getMessage() == null) {
                     throw new StreamLoadException("stream load failed, response error : " + entityStr);
                 } else if (!streamLoadResponse.isSuccess()) {
-                    throw new StreamLoadException(
-                            "stream load failed, txnId: " + streamLoadResponse.getTxnId()
-                                    + ", status: " + streamLoadResponse.getStatus()
-                                    + ", msg: " + streamLoadResponse.getMessage());
+                    if (StreamLoadLabelManager.isAlreadyCommitted(labelReused, streamLoadResponse.getStatus(),
+                            streamLoadResponse.getExistingJobStatus())) {
+                        // The batch we are retrying already committed under this reused label, so
+                        // Doris rejects the duplicate. The rows are already present — treat the
+                        // retry as a success instead of writing them twice (exactly-once on retry).
+                        logger.info("reused label {} already committed; retry is a no-op", labelManager.currentLabel());
+                    } else {
+                        throw new StreamLoadException(
+                                "stream load failed, txnId: " + streamLoadResponse.getTxnId()
+                                        + ", status: " + streamLoadResponse.getStatus()
+                                        + ", msg: " + streamLoadResponse.getMessage());
+                    }
                 }
             } catch (Exception e) {
                 logger.error("stream load exception", e);

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/StreamLoadLabelManager.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/StreamLoadLabelManager.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.client.write;
+
+import org.apache.doris.spark.exception.OptionRequiredException;
+
+import java.io.Serializable;
+
+/**
+ * Owns the stream-load label across batches so that a retry of a failed batch can reuse the previous
+ * label.
+ *
+ * <p>An auto-commit (non-2PC) batch that fails on the client side may have actually committed on the
+ * backend (e.g. its HTTP response was lost). Reusing the same label on the retry lets the backend
+ * reject the retry as a duplicate, so the rows are written exactly once instead of twice. A fresh
+ * label is minted for every new (committed) batch, so normal writes are unaffected.
+ *
+ * <p>Two-phase-commit loads do NOT reuse labels: their exactly-once guarantee comes from the
+ * precommit/commit protocol (a retry begins a fresh transaction and the orphaned precommitted one
+ * aborts), and a reused-label collision carries no usable transaction id.
+ */
+class StreamLoadLabelManager implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Backend status returned when a label has already been used by another load. */
+    static final String LABEL_ALREADY_EXISTS_STATUS = "Label Already Exists";
+
+    /**
+     * {@code ExistingJobStatus} value meaning the load that already used the label has COMMITTED.
+     * Other values ("RUNNING", "PRECOMMITTED") mean the original is still in flight and may yet
+     * abort, so they must NOT be treated as a successful no-op.
+     */
+    static final String EXISTING_JOB_FINISHED = "FINISHED";
+
+    /** Generates a fresh label; may fail when a required option is missing. */
+    @FunctionalInterface
+    interface LabelGenerator {
+        String generate() throws OptionRequiredException;
+    }
+
+    private final boolean twoPhaseCommitEnabled;
+    private volatile String currentLabel;
+    private boolean reuseLabel = false;
+
+    StreamLoadLabelManager(boolean twoPhaseCommitEnabled) {
+        this.twoPhaseCommitEnabled = twoPhaseCommitEnabled;
+    }
+
+    /**
+     * Returns the label to use for the next batch: the current label when retrying a failed batch,
+     * otherwise a freshly generated one.
+     */
+    String labelForNextBatch(LabelGenerator generator) throws OptionRequiredException {
+        if (!reuseLabel || currentLabel == null) {
+            currentLabel = generator.generate();
+        }
+        return currentLabel;
+    }
+
+    /** The label of the most recently started batch (may be {@code null} before the first batch). */
+    String currentLabel() {
+        return currentLabel;
+    }
+
+    /** Whether the current batch is reusing a previous (failed) batch's label. */
+    boolean isReusingLabel() {
+        return reuseLabel;
+    }
+
+    /** The previous batch committed: the next batch must use a fresh label. */
+    void onBatchCommitted() {
+        reuseLabel = false;
+    }
+
+    /**
+     * The previous batch failed: reuse the same label on the retry so the backend can deduplicate it.
+     * Only applies to auto-commit loads; 2PC loads always get a fresh label.
+     */
+    void onBatchFailed() {
+        if (!twoPhaseCommitEnabled) {
+            reuseLabel = true;
+        }
+    }
+
+    /**
+     * Whether a failed-load response means the (reused) label's load already COMMITTED — i.e. the
+     * retry is an idempotent no-op and the rows are already present, so it can be treated as success.
+     *
+     * <p>Requires both that we are retrying with a reused label and that the backend reports the
+     * existing job as FINISHED. A still-RUNNING/PRECOMMITTED original may still abort, so it stays a
+     * retriable failure rather than being masked as success (which would silently lose those rows).
+     */
+    static boolean isAlreadyCommitted(boolean labelReused, String status, String existingJobStatus) {
+        return labelReused
+                && LABEL_ALREADY_EXISTS_STATUS.equalsIgnoreCase(status)
+                && EXISTING_JOB_FINISHED.equalsIgnoreCase(existingJobStatus);
+    }
+}

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/sql/DorisRow.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/sql/DorisRow.scala
@@ -54,6 +54,4 @@ private[spark] class DorisRow(rowOrder: Seq[String]) extends Row {
   override def getString(i: Int): String = get(i).toString
 
   override def copy(): Row = this
-
-  override def toSeq: Seq[Any] = values
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/sql/sources/DorisRelation.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/sql/sources/DorisRelation.scala
@@ -48,7 +48,7 @@ private[sql] class DorisRelation(
     val arrayNativeType = cfg.getValue(DorisOptions.DORIS_READ_ARRAY_NATIVE_TYPE)
     StructType(dorisSchema.getProperties.asScala.map(field => {
       StructField(field.getName, SchemaConvertors.toCatalystType(field.getType, field.getPrecision, field.getScale, arrayNativeType))
-    }))
+    }).toArray)
 
   }
 

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/testcase/TestStreamLoadForArrowType.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/testcase/TestStreamLoadForArrowType.scala
@@ -137,7 +137,7 @@ object TestStreamLoadForArrowType {
       inputList.append(row)
     }
 
-    val rdd = spark.sparkContext.parallelize(inputList, 1)
+    val rdd = spark.sparkContext.parallelize(inputList.toList, 1)
     val df = spark.createDataFrame(rdd, schema).toDF()
 
     df.write
@@ -242,7 +242,7 @@ object TestStreamLoadForArrowType {
       inputList.append(row)
     }
 
-    val rdd = spark.sparkContext.parallelize(inputList, 1)
+    val rdd = spark.sparkContext.parallelize(inputList.toList, 1)
     val df = spark.createDataFrame(rdd, schema).toDF()
 
     df.write
@@ -347,7 +347,7 @@ object TestStreamLoadForArrowType {
       inputList.append(row)
     }
 
-    val rdd = spark.sparkContext.parallelize(inputList, 1)
+    val rdd = spark.sparkContext.parallelize(inputList.toList, 1)
     val df = spark.createDataFrame(rdd, schema).toDF()
 
     df.write
@@ -444,7 +444,7 @@ CREATE TABLE `spark_connector_struct` (
       inputList.append(row)
     }
 
-    val rdd = spark.sparkContext.parallelize(inputList, 1)
+    val rdd = spark.sparkContext.parallelize(inputList.toList, 1)
     val df = spark.createDataFrame(rdd, schema).toDF()
 
     df.write

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/Retry.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/doris/spark/util/Retry.scala
@@ -20,7 +20,7 @@ package org.apache.doris.spark.util
 import org.slf4j.Logger
 
 import java.time.Duration
-import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
@@ -38,11 +38,40 @@ object Retry {
       case Failure(exception: T) if retryTimes > 0 =>
         logger.warn("Execution failed caused by: {}", exception.getMessage)
         logger.warn(s"$retryTimes times retry remaining, the next attempt will be in ${interval.toMillis} ms")
-        LockSupport.parkNanos(interval.toNanos)
+        sleepBeforeRetry(interval)
         h
         exec(retryTimes - 1, interval, logger)(f)(h)
       case Failure(exception) => Failure(exception)
     }
+  }
+
+  /**
+   * Wait for the full interval before the next retry.
+   *
+   * [[java.util.concurrent.locks.LockSupport.parkNanos]] may return before the requested time on a
+   * spurious wakeup or when another thread unparks this one. The stream-load processor interrupts
+   * the task thread on an async load failure (to unblock a blocking pipe write), and an interrupt
+   * also unparks a parked thread, so a single `parkNanos` for the backoff is repeatedly cut short
+   * and the configured retry interval collapses to a few milliseconds — most visibly under Spark
+   * 4.x. That both hammers the backend with retries and breaks failover that relies on the interval.
+   *
+   * Use [[Thread.sleep]] (via [[TimeUnit]]), which is not affected by `unpark`, and loop until the
+   * full interval has elapsed. A spurious interrupt is absorbed (the interrupt status is restored
+   * afterwards) so the interval is still honored.
+   */
+  private def sleepBeforeRetry(interval: Duration): Unit = {
+    val deadlineNanos = System.nanoTime() + interval.toNanos
+    var remainingNanos = interval.toNanos
+    var interrupted = false
+    while (remainingNanos > 0L) {
+      try {
+        TimeUnit.NANOSECONDS.sleep(remainingNanos)
+      } catch {
+        case _: InterruptedException => interrupted = true
+      }
+      remainingNanos = deadlineNanos - System.nanoTime()
+    }
+    if (interrupted) Thread.currentThread().interrupt()
   }
 
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/spark/sql/util/DorisArrowUtils.scala
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/scala/org/apache/spark/sql/util/DorisArrowUtils.scala
@@ -106,7 +106,7 @@ object DorisArrowUtils {
           val dt = fromArrowField(child)
           StructField(child.getName, dt, child.isNullable)
         }
-        StructType(fields)
+        StructType(fields.toArray)
       case arrowType => fromArrowType(arrowType)
     }
   }

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/StreamLoadLabelManagerTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/StreamLoadLabelManagerTest.java
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.client.write;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StreamLoadLabelManagerTest {
+
+    private static final String LABEL_EXISTS = "Label Already Exists";
+
+    /** A deterministic label generator producing label-0, label-1, ... */
+    private static StreamLoadLabelManager.LabelGenerator counting(AtomicInteger seq) {
+        return () -> "label-" + seq.getAndIncrement();
+    }
+
+    /** An auto-commit (non-2PC) manager — the mode that reuses labels. */
+    private static StreamLoadLabelManager autoCommit() {
+        return new StreamLoadLabelManager(false);
+    }
+
+    @Test
+    public void firstBatchGeneratesAFreshLabel() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        Assertions.assertNull(mgr.currentLabel());
+        Assertions.assertFalse(mgr.isReusingLabel());
+
+        String label = mgr.labelForNextBatch(counting(new AtomicInteger()));
+        Assertions.assertEquals("label-0", label);
+        Assertions.assertEquals("label-0", mgr.currentLabel());
+    }
+
+    @Test
+    public void committedBatchesEachGetAFreshLabel() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq));
+        mgr.onBatchCommitted();
+        String second = mgr.labelForNextBatch(counting(seq));
+
+        Assertions.assertEquals("label-0", first);
+        Assertions.assertEquals("label-1", second);
+        Assertions.assertFalse(mgr.isReusingLabel());
+    }
+
+    @Test
+    public void retryReusesTheFailedBatchLabel() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq));
+        mgr.onBatchFailed();
+        Assertions.assertTrue(mgr.isReusingLabel());
+
+        String retry = mgr.labelForNextBatch(counting(seq));
+        Assertions.assertEquals(first, retry, "retry must reuse the failed batch's label");
+        Assertions.assertEquals(1, seq.get(), "no new label should be generated on retry");
+    }
+
+    @Test
+    public void freshLabelResumesAfterASuccessfulRetry() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        mgr.labelForNextBatch(counting(seq)); // label-0
+        mgr.onBatchFailed();
+        mgr.labelForNextBatch(counting(seq)); // reuse label-0
+        mgr.onBatchCommitted();               // retry committed
+        String next = mgr.labelForNextBatch(counting(seq));
+
+        Assertions.assertEquals("label-1", next);
+        Assertions.assertFalse(mgr.isReusingLabel());
+    }
+
+    @Test
+    public void twoPhaseCommitNeverReusesLabel() throws Exception {
+        // Under 2PC, a reused-label collision carries no usable txn id, so labels must stay fresh —
+        // exactly-once is handled by the precommit/commit protocol instead.
+        StreamLoadLabelManager mgr = new StreamLoadLabelManager(true);
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq));
+        mgr.onBatchFailed();
+        Assertions.assertFalse(mgr.isReusingLabel(), "2PC must not reuse labels");
+
+        String retry = mgr.labelForNextBatch(counting(seq));
+        Assertions.assertEquals("label-0", first);
+        Assertions.assertEquals("label-1", retry, "2PC retry must get a fresh label");
+    }
+
+    @Test
+    public void isSerializableWithState() throws Exception {
+        // The Spark 2.x/3.x DorisWriter serializes the committer (which holds this manager) to the
+        // executors, so the manager must stay Serializable and round-trip its state.
+        StreamLoadLabelManager mgr = autoCommit();
+        mgr.labelForNextBatch(counting(new AtomicInteger())); // label-0
+        mgr.onBatchFailed();
+
+        byte[] bytes;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(mgr);
+            bytes = bos.toByteArray();
+        }
+        StreamLoadLabelManager restored;
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            restored = (StreamLoadLabelManager) ois.readObject();
+        }
+
+        Assertions.assertEquals("label-0", restored.currentLabel());
+        Assertions.assertTrue(restored.isReusingLabel());
+    }
+
+    @Test
+    public void alreadyCommittedOnlyForReusedLabelThatActuallyFinished() {
+        // The exactly-once no-op: a reused label whose existing load has COMMITTED (FINISHED).
+        Assertions.assertTrue(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, "FINISHED"));
+        Assertions.assertTrue(StreamLoadLabelManager.isAlreadyCommitted(true, "label already exists", "finished"));
+
+        // A still-in-flight original may yet abort — must NOT be masked as success (would lose data).
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, "RUNNING"));
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, "PRECOMMITTED"));
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, null));
+
+        // A fresh-label collision is a real error, not a dedup no-op.
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(false, LABEL_EXISTS, "FINISHED"));
+        // Any other failure status is a real error even on a reused label.
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, "Fail", "FINISHED"));
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, null, "FINISHED"));
+    }
+}

--- a/spark-doris-connector/spark-doris-connector-it/pom.xml
+++ b/spark-doris-connector/spark-doris-connector-it/pom.xml
@@ -82,12 +82,6 @@
             <version>8.0.33</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>
@@ -99,9 +93,34 @@
             <properties>
                 <spark.doris.connector.artifactId>spark-doris-connector-spark-2</spark.doris.connector.artifactId>
             </properties>
+            <dependencies>
+                <!-- Spark 2.x / 3.x use slf4j 1.7 + log4j 1.2 -->
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <version>1.7.25</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
         </profile>
         <profile>
             <id>spark-3-it</id>
+            <properties>
+                <spark.doris.connector.artifactId>spark-doris-connector-spark-${spark.major.version}</spark.doris.connector.artifactId>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <version>1.7.25</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <!-- Spark 4.x brings its own slf4j 2.x + log4j 2.x binding; the slf4j 1.7
+                 binding above would clash (NoSuchFieldError: mdc). -->
+            <id>spark-4-it</id>
             <properties>
                 <spark.doris.connector.artifactId>spark-doris-connector-spark-${spark.major.version}</spark.doris.connector.artifactId>
             </properties>

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/pom.xml
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.doris</groupId>
+        <artifactId>spark-doris-connector</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>spark-doris-connector-spark-4-base</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.doris</groupId>
+            <artifactId>spark-doris-connector-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.major.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableBase.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableBase.scala
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.catalog
+
+import org.apache.doris.spark.client.DorisFrontendClient
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.doris.spark.rest.models.Schema
+import org.apache.doris.spark.util.SchemaConvertors
+import org.apache.spark.sql.connector.catalog.TableCapability._
+import org.apache.spark.sql.connector.catalog.{Identifier, SupportsRead, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+
+abstract class DorisTableBase(identifier: Identifier, config: DorisConfig, schema: Option[StructType]) extends Table with SupportsRead with SupportsWrite {
+
+  private lazy val frontend:DorisFrontendClient = new DorisFrontendClient(config)
+
+  override def name(): String = identifier.toString
+
+  override def schema(): StructType = schema.getOrElse({
+    val dorisSchema = frontend.getTableSchema(identifier.namespace()(0), identifier.name())
+    dorisSchemaToStructType(dorisSchema)
+  })
+
+  override def capabilities(): util.Set[TableCapability] = {
+    val capabilities = mutable.Set(BATCH_READ,
+      BATCH_WRITE,
+      STREAMING_WRITE,
+      TRUNCATE)
+    val properties = config.getSinkProperties
+    val partialColumnsEnabled = properties.containsKey(DorisOptions.PARTIAL_COLUMNS) && "true".equalsIgnoreCase(properties.get(DorisOptions.PARTIAL_COLUMNS))
+    val schemaLessEnabled = config.getValue(DorisOptions.DORIS_WRITE_SCHEMA_LESS)
+    if (partialColumnsEnabled || schemaLessEnabled) {
+      capabilities += ACCEPT_ANY_SCHEMA
+    }
+    capabilities.asJava
+  }
+
+  override def newScanBuilder(caseInsensitiveStringMap: CaseInsensitiveStringMap): ScanBuilder = {
+    config.setProperty(DorisOptions.DORIS_TABLE_IDENTIFIER, name())
+    createScanBuilder(config, schema())
+  }
+
+  override def newWriteBuilder(logicalWriteInfo: LogicalWriteInfo): WriteBuilder = {
+    config.setProperty(DorisOptions.DORIS_TABLE_IDENTIFIER, name())
+    createWriteBuilder(config, logicalWriteInfo.schema())
+  }
+
+  private def dorisSchemaToStructType(dorisSchema: Schema): StructType = {
+    val arrayNativeType = config.getValue(DorisOptions.DORIS_READ_ARRAY_NATIVE_TYPE)
+    StructType(dorisSchema.getProperties.asScala.map(field => {
+      StructField(field.getName, SchemaConvertors.toCatalystType(field.getType, field.getPrecision, field.getScale, arrayNativeType))
+    }).toArray)
+  }
+
+  protected def createScanBuilder(config: DorisConfig, schema: StructType): ScanBuilder
+
+  protected def createWriteBuilder(config: DorisConfig, schema: StructType): WriteBuilder
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableCatalogBase.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableCatalogBase.scala
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.catalog
+
+import org.apache.doris.spark.client.DorisFrontendClient
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException
+import org.apache.spark.sql.connector.catalog.{Identifier, NamespaceChange, SupportsNamespaces, Table, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+import scala.collection.JavaConverters._
+
+trait DorisTableCatalogBase extends TableCatalog with SupportsNamespaces {
+
+  protected var catalogName: Option[String] = None
+
+  protected var dorisConfig: DorisConfig = _
+
+  protected var frontend: DorisFrontendClient = _
+
+  override def name(): String = {
+    require(catalogName.nonEmpty, "The Doris table catalog is not initialed")
+    catalogName.get
+  }
+
+  override def initialize(name: String, caseInsensitiveStringMap: CaseInsensitiveStringMap): Unit = {
+    assert(catalogName.isEmpty, "The Doris table catalog is already initialed")
+    catalogName = Some(name)
+    dorisConfig = DorisConfig.fromMap(caseInsensitiveStringMap, true)
+    frontend = new DorisFrontendClient(dorisConfig)
+  }
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    frontend.listTables(namespace).asScala.map(i => Identifier.of(i.getLeft, i.getValue)).toArray
+  }
+
+  override def loadTable(identifier: Identifier): Table = {
+    checkIdentifier(identifier)
+    newTableInstance(identifier, DorisConfig.fromMap((dorisConfig.toMap.asScala +
+      (DorisOptions.DORIS_TABLE_IDENTIFIER.getName -> getFullTableName(identifier))).asJava, false), None)
+  }
+
+  override def createTable(identifier: Identifier, structType: StructType, transforms: Array[Transform], map: util.Map[String, String]): Table = throw new UnsupportedOperationException()
+
+  override def alterTable(identifier: Identifier, tableChanges: TableChange*): Table = throw new UnsupportedOperationException()
+
+  override def dropTable(identifier: Identifier): Boolean = throw new UnsupportedOperationException()
+
+  override def renameTable(identifier: Identifier, identifier1: Identifier): Unit = throw new UnsupportedOperationException()
+
+  override def listNamespaces(): Array[Array[String]] = {
+    frontend.listDatabases().map(Array(_))
+  }
+
+  override def listNamespaces(namespace: Array[String]): Array[Array[String]] = {
+    namespace match {
+      case Array() => listNamespaces()
+      case Array(_) if frontend.databaseExists(namespace(0)) => Array()
+      case _ => throw new NoSuchNamespaceException(namespace)
+    }
+  }
+
+  override def loadNamespaceMetadata(namespace: Array[String]): util.Map[String, String] = {
+    namespace match {
+      case Array(database) =>
+        if (!frontend.databaseExists(database)) {
+          throw new NoSuchNamespaceException(namespace)
+        }
+        new util.HashMap[String, String]()
+      case _ => throw new NoSuchNamespaceException(namespace)
+    }
+  }
+
+  override def createNamespace(namespace: Array[String], metadata: util.Map[String, String]): Unit = throw new UnsupportedOperationException()
+
+  override def alterNamespace(namespace: Array[String], changes: NamespaceChange*): Unit = throw new UnsupportedOperationException()
+
+  private def checkIdentifier(identifier: Identifier): Unit = {
+    if (identifier.namespace().length > 1) {
+      throw new NoSuchNamespaceException(identifier.namespace())
+    }
+  }
+
+  private def getFullTableName(identifier: Identifier): String = {
+    (identifier.namespace() :+ identifier.name()).map(item => s"""`$item`""").mkString(".")
+  }
+
+  def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableProviderBase.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/catalog/DorisTableProviderBase.scala
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.catalog
+
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableProvider}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import java.util
+
+abstract class DorisTableProviderBase extends TableProvider {
+
+  protected var t: Table = _
+
+  override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
+    if (t == null) t = getTable(options)
+    t.schema()
+  }
+
+  override def getTable(schema: StructType, partitioning: Array[Transform], properties: util.Map[String, String]): Table = {
+    if (t != null) t
+    else {
+      val dorisConfig = DorisConfig.fromMap(properties, false)
+      val tableIdentifier = dorisConfig.getValue(DorisOptions.DORIS_TABLE_IDENTIFIER)
+      val tableIdentifierArr = tableIdentifier.split("\\.")
+      newTableInstance(Identifier.of(Array[String](tableIdentifierArr(0)), tableIdentifierArr(1)), dorisConfig, Some(schema))
+    }
+  }
+
+  private def getTable(options: CaseInsensitiveStringMap): Table = {
+    if (t != null) t
+    else {
+      val dorisConfig = DorisConfig.fromMap(options, false)
+      val tableIdentifier = dorisConfig.getValue(DorisOptions.DORIS_TABLE_IDENTIFIER)
+      val tableIdentifierArr = tableIdentifier.split("\\.")
+      newTableInstance(Identifier.of(Array[String](tableIdentifierArr(0)), tableIdentifierArr(1)), dorisConfig, None)
+    }
+  }
+
+  def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table;
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/AbstractDorisScan.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/AbstractDorisScan.scala
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.client.entity.{Backend, DorisReaderPartition}
+import org.apache.doris.spark.client.read.ReaderPartitionGenerator
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+import scala.language.implicitConversions
+
+abstract class AbstractDorisScan(config: DorisConfig, schema: StructType) extends Scan with Batch with Logging {
+
+  private val scanMode = ScanMode.valueOf(config.getValue(DorisOptions.READ_MODE).toUpperCase)
+
+  override def readSchema(): StructType = schema
+
+  override def toBatch: Batch = this
+
+  override def planInputPartitions(): Array[InputPartition] = {
+    ReaderPartitionGenerator.generatePartitions(config, schema.names, compiledFilters(), getLimit,
+      SQLConf.get.datetimeJava8ApiEnabled)
+      .map(toInputPartition)
+  }
+
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    new DorisPartitionReaderFactory(readSchema(), scanMode, config)
+  }
+
+  private def toInputPartition(rp: DorisReaderPartition): DorisInputPartition =
+    DorisInputPartition(rp.getDatabase, rp.getTable, rp.getBackend, rp.getTablets.map(_.toLong), rp.getOpaquedQueryPlan,
+      rp.getReadColumns, rp.getFilters, rp.getLimit, rp.getDateTimeJava8APIEnabled)
+
+  protected def compiledFilters(): Array[String]
+
+  protected def getLimit: Int = -1
+
+}
+
+case class DorisInputPartition(database: String, table: String, backend: Backend, tablets: Array[Long],
+                               opaquedQueryPlan: String, readCols: Array[String], predicates: Array[String],
+                               limit: Int = -1, datetimeJava8ApiEnabled: Boolean) extends InputPartition

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisPartitionReader.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisPartitionReader.scala
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.client.entity.DorisReaderPartition
+import org.apache.doris.spark.client.read.{DorisFlightSqlReader, DorisReader, DorisThriftReader}
+import org.apache.doris.spark.config.DorisConfig
+import org.apache.doris.spark.util.RowConvertors
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader}
+import org.apache.spark.sql.types.StructType
+
+import scala.language.implicitConversions
+
+class DorisPartitionReader(inputPartition: InputPartition, schema: StructType, mode: ScanMode, config: DorisConfig)
+  extends PartitionReader[InternalRow] {
+
+  private implicit def toReaderPartition(inputPart: DorisInputPartition): DorisReaderPartition = {
+    val tablets = inputPart.tablets.map(java.lang.Long.valueOf)
+    new DorisReaderPartition(inputPart.database, inputPart.table, inputPart.backend, tablets,
+      inputPart.opaquedQueryPlan, inputPart.readCols, inputPart.predicates, inputPart.limit, config, inputPart.datetimeJava8ApiEnabled)
+  }
+
+  private lazy val reader: DorisReader = {
+    mode match {
+      case ScanMode.THRIFT => new DorisThriftReader(inputPartition.asInstanceOf[DorisInputPartition])
+      case ScanMode.ARROW => new DorisFlightSqlReader(inputPartition.asInstanceOf[DorisInputPartition])
+      case _ => throw new UnsupportedOperationException()
+    }
+  }
+
+  private val datetimeJava8ApiEnabled: Boolean = inputPartition.asInstanceOf[DorisInputPartition].datetimeJava8ApiEnabled
+
+  override def next(): Boolean = reader.hasNext
+
+  override def get(): InternalRow = {
+    val values = reader.next().asInstanceOf[Array[Any]]
+    val row = new GenericInternalRow(schema.length)
+    if (values.nonEmpty) {
+      values.zipWithIndex.foreach {
+        case (value, index) =>
+          if (value == null) row.setNullAt(index)
+          else {
+            val dataType = schema.fields(index).dataType
+            val catalystValue = RowConvertors.convertValue(value, dataType, datetimeJava8ApiEnabled)
+            row.update(index, catalystValue)
+          }
+      }
+    }
+    row
+  }
+
+  override def close(): Unit = {
+    if (reader != null) {
+      reader.close()
+    }
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisPartitionReaderFactory.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisPartitionReaderFactory.scala
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.config.DorisConfig
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.types.StructType
+
+class DorisPartitionReaderFactory(schema: StructType, mode: ScanMode, config: DorisConfig) extends PartitionReaderFactory {
+
+  override def createReader(inputPartition: InputPartition): PartitionReader[InternalRow] = {
+    new DorisPartitionReader(inputPartition, schema, mode, config)
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisScan.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisScan.scala
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.doris.spark.util.DorisDialects
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+
+import scala.language.implicitConversions
+
+class DorisScan(config: DorisConfig, schema: StructType, filters: Array[Filter]) extends AbstractDorisScan(config, schema) with Logging {
+  override protected def compiledFilters(): Array[String] = {
+    val inValueLengthLimit = config.getValue(DorisOptions.DORIS_FILTER_QUERY_IN_MAX_COUNT)
+    filters.map(DorisDialects.compileFilter(_, inValueLengthLimit)).filter(_.isDefined).map(_.get)
+  }
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisScanBuilderBase.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/DorisScanBuilderBase.scala
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.spark.sql.connector.read.{ScanBuilder, SupportsPushDownRequiredColumns}
+import org.apache.spark.sql.types.StructType
+
+protected[spark] abstract class DorisScanBuilderBase(config: DorisConfig, schema: StructType) extends ScanBuilder
+  with SupportsPushDownRequiredColumns {
+
+  protected var readSchema: StructType = {
+    if (config.contains(DorisOptions.DORIS_READ_FIELDS)) {
+      val dorisReadFields = config.getValue(DorisOptions.DORIS_READ_FIELDS).split(",").map(_.trim.replaceAll("`", ""))
+      doPruneColumns(schema, dorisReadFields)
+    } else {
+      schema
+    }
+  }
+
+  override def pruneColumns(requiredSchema: StructType): Unit = {
+    readSchema = doPruneColumns(readSchema, requiredSchema.fieldNames)
+  }
+
+  private def doPruneColumns(originSchema: StructType, requiredCols: Array[String]): StructType = {
+    if (requiredCols.nonEmpty) {
+      val fields = originSchema.fields.filter(
+        field => requiredCols.contains(field.name)
+      )
+      if (fields.isEmpty) {
+        throw new IllegalArgumentException("No required columns found")
+      }
+      StructType(fields)
+    } else originSchema
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/ScanMode.java
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/read/ScanMode.java
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read;
+
+public enum ScanMode {
+    THRIFT,ARROW
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/sql/sources/DorisSourceProvider.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/sql/sources/DorisSourceProvider.scala
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.sql.sources
+
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.sources.{BaseRelation, RelationProvider}
+
+trait DorisSourceProvider extends RelationProvider {
+
+  override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation = {
+    new DorisRelation(sqlContext, parameters)
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisDataWriter.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisDataWriter.scala
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.write
+
+import org.apache.doris.spark.client.write.{CopyIntoProcessor, DorisCommitter, DorisWriter, StreamLoadProcessor}
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.doris.spark.util.Retry
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.write.{DataWriter, WriterCommitMessage}
+import org.apache.spark.sql.types.StructType
+
+import java.time.Duration
+import java.util.concurrent.locks.LockSupport
+import scala.collection.mutable
+import scala.util.{Failure, Success}
+
+class DorisDataWriter(config: DorisConfig, schema: StructType, partitionId: Int, taskId: Long, epochId: Long = -1) extends DataWriter[InternalRow] with Logging {
+
+  private val (writer: DorisWriter[InternalRow], committer: DorisCommitter) =
+    config.getValue(DorisOptions.LOAD_MODE) match {
+      case "stream_load" => (new StreamLoadProcessor(config, schema), new StreamLoadProcessor(config, schema))
+      case "copy_into" => (new CopyIntoProcessor(config, schema), new CopyIntoProcessor(config, schema))
+      case mode => throw new IllegalArgumentException("Unsupported load mode: " + mode)
+    }
+
+  private val batchIntervalMs = config.getValue(DorisOptions.DORIS_SINK_BATCH_INTERVAL_MS)
+
+  private val retries = config.getValue(DorisOptions.DORIS_SINK_MAX_RETRIES)
+
+  private val retryIntervalMs = config.getValue(DorisOptions.DORIS_SINK_RETRY_INTERVAL_MS)
+
+  private val twoPhaseCommitEnabled = config.getValue(DorisOptions.DORIS_SINK_ENABLE_2PC)
+
+  private val committedMessages = mutable.Buffer[String]()
+
+  private lazy val recordBuffer = mutable.Buffer[InternalRow]()
+
+  override def write(record: InternalRow): Unit = loadBatchWithRetries(record)
+
+  override def commit(): WriterCommitMessage = {
+    val txnId = Option(writer.stop())
+    if (twoPhaseCommitEnabled) {
+      if (txnId.isDefined) {
+        committedMessages += txnId.get
+      } else {
+        log.warn("No txn {} to commit batch", txnId)
+      }
+    }
+    DorisWriterCommitMessage(partitionId, taskId, epochId, committedMessages.toArray)
+  }
+
+  override def abort(): Unit = {
+    if (committedMessages.nonEmpty) {
+      committedMessages.foreach(msg => committer.abort(msg))
+    }
+    close()
+  }
+
+  override def close(): Unit = {
+    if (writer != null) {
+      writer.close()
+    }
+  }
+
+  @throws[Exception]
+  private def loadBatchWithRetries(record: InternalRow): Unit = {
+    var isRetrying = false
+    Retry.exec[Unit, Exception](retries, Duration.ofMillis(retryIntervalMs.toLong), log) {
+      if (isRetrying) {
+        // retrying, reload data from buffer
+        while (writer.getBatchCount < recordBuffer.size){
+          val idx = writer.getBatchCount
+          writer.load(recordBuffer(idx))
+        }
+        isRetrying = false
+      }
+      if (writer.endOfBatch()) {
+        // end of batch, stop batch write
+        val txnId = Option(writer.stop())
+        if (twoPhaseCommitEnabled) {
+          if (txnId.isDefined) {
+            committedMessages += txnId.get
+          } else {
+            throw new Exception("Failed to end batch write")
+          }
+        }
+        // clear buffer if retry is enabled
+        if (retries > 0) {
+          recordBuffer.clear()
+        }
+        writer.resetBatchCount()
+        LockSupport.parkNanos(Duration.ofMillis(batchIntervalMs.toLong).toNanos)
+      }
+      writer.load(record)
+    } {
+      // batch write failed, set retry flag and reset batch count
+      isRetrying = true
+      writer.resetBatchCount()
+    } match {
+      case Success(_) => if (retries > 0) recordBuffer += record
+      case Failure(exception) => throw new Exception(exception)
+    }
+  }
+
+}
+
+case class DorisWriterCommitMessage(partitionId: Int, taskId: Long, epochId: Long, commitMessages: Array[String]) extends WriterCommitMessage

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisDataWriterFactory.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisDataWriterFactory.scala
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.write
+
+import org.apache.doris.spark.config.DorisConfig
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.write.streaming.StreamingDataWriterFactory
+import org.apache.spark.sql.connector.write.{DataWriter, DataWriterFactory}
+import org.apache.spark.sql.types.StructType
+
+class DorisDataWriterFactory(config: DorisConfig, schema: StructType) extends DataWriterFactory with StreamingDataWriterFactory {
+
+  // for batch write
+  override def createWriter(partitionId: Int, taskId: Long): DataWriter[InternalRow] = {
+    new DorisDataWriter(config, schema, partitionId, taskId)
+  }
+
+  // for streaming write
+  override def createWriter(partitionId: Int, taskId: Long, epochId: Long): DataWriter[InternalRow] = {
+    new DorisDataWriter(config, schema, partitionId, taskId, epochId)
+  }
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisWrite.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisWrite.scala
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.write
+
+import org.apache.doris.spark.client.write.{CopyIntoProcessor, DorisCommitter, StreamLoadProcessor}
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.spark.sql.connector.write.streaming.{StreamingDataWriterFactory, StreamingWrite}
+import org.apache.spark.sql.connector.write.{BatchWrite, DataWriterFactory, PhysicalWriteInfo, WriterCommitMessage}
+import org.apache.spark.sql.types.StructType
+import org.slf4j.LoggerFactory
+
+class DorisWrite(config: DorisConfig, schema: StructType) extends BatchWrite with StreamingWrite {
+
+  private val LOG = LoggerFactory.getLogger(classOf[DorisWrite])
+
+  private val committer: DorisCommitter = config.getValue(DorisOptions.LOAD_MODE) match {
+    case "stream_load" => new StreamLoadProcessor(config, schema)
+    case "copy_into" => new CopyIntoProcessor(config, schema)
+    case _ => throw new IllegalArgumentException()
+  }
+
+  private var lastCommittedEpoch: Option[Long] = None
+
+  private val committedEpochLock = new AnyRef
+
+  override def createBatchWriterFactory(physicalWriteInfo: PhysicalWriteInfo): DataWriterFactory = {
+    new DorisDataWriterFactory(config, schema)
+  }
+
+  // for batch write
+  override def commit(writerCommitMessages: Array[WriterCommitMessage]): Unit = {
+    if (writerCommitMessages != null && writerCommitMessages.nonEmpty) {
+      writerCommitMessages.filter(_ != null)
+        .foreach(_.asInstanceOf[DorisWriterCommitMessage].commitMessages.foreach(committer.commit))
+    }
+  }
+
+  // for batch write
+  override def abort(writerCommitMessages: Array[WriterCommitMessage]): Unit = {
+    LOG.info("writerCommitMessages size: " + writerCommitMessages.length)
+    if (writerCommitMessages.exists(_ != null) && writerCommitMessages.nonEmpty) {
+      writerCommitMessages.filter(_ != null)
+        .foreach(_.asInstanceOf[DorisWriterCommitMessage].commitMessages.foreach(committer.abort))
+    }
+  }
+
+  override def useCommitCoordinator(): Boolean = true
+
+  override def createStreamingWriterFactory(physicalWriteInfo: PhysicalWriteInfo): StreamingDataWriterFactory = {
+    new DorisDataWriterFactory(config, schema)
+  }
+
+  // for streaming write
+  override def commit(epochId: Long, writerCommitMessages: Array[WriterCommitMessage]): Unit = {
+    committedEpochLock.synchronized {
+      if (lastCommittedEpoch.isEmpty || epochId > lastCommittedEpoch.get && writerCommitMessages.exists(_ != null)) {
+        writerCommitMessages.foreach(_.asInstanceOf[DorisWriterCommitMessage].commitMessages.foreach(committer.commit))
+        lastCommittedEpoch = Some(epochId)
+      }
+    }
+  }
+
+  // for streaming write
+  override def abort(epochId: Long, writerCommitMessages: Array[WriterCommitMessage]): Unit = {
+    committedEpochLock.synchronized {
+      if ((lastCommittedEpoch.isEmpty || epochId > lastCommittedEpoch.get) && writerCommitMessages.exists(_ != null)) {
+        writerCommitMessages.foreach(_.asInstanceOf[DorisWriterCommitMessage].commitMessages.foreach(committer.abort))
+      }
+    }
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisWriteBuilder.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4-base/src/main/scala/org/apache/doris/spark/write/DorisWriteBuilder.scala
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.write
+
+import org.apache.doris.spark.client.DorisFrontendClient
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.spark.sql.connector.write.streaming.StreamingWrite
+import org.apache.spark.sql.connector.write.{BatchWrite, SupportsTruncate, WriteBuilder}
+import org.apache.spark.sql.types.StructType
+
+class DorisWriteBuilder(config: DorisConfig, schema: StructType) extends WriteBuilder with SupportsTruncate {
+
+  private var isTruncate = false
+
+  override def buildForBatch(): BatchWrite = {
+    if (isTruncate) {
+      val client = new DorisFrontendClient(config)
+      val tableDb = config.getValue(DorisOptions.DORIS_TABLE_IDENTIFIER).split("\\.")
+      client.truncateTable(tableDb(0), tableDb(1))
+    }
+    new DorisWrite(config, schema)
+  }
+
+  override def buildForStreaming(): StreamingWrite = {
+    new DorisWrite(config, schema)
+  }
+
+  override def truncate(): WriteBuilder = {
+    isTruncate = true
+    this
+  }
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/pom.xml
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.doris</groupId>
+        <artifactId>spark-doris-connector</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>spark-doris-connector-spark-4.0</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>4.0.0</spark.version>
+        <spark.major.version>4.0</spark.major.version>
+        <scala.version>2.13.16</scala.version>
+        <scala.major.version>2.13</scala.major.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.doris</groupId>
+            <artifactId>spark-doris-connector-spark-4-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.major.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+org.apache.doris.spark.sql.sources.DorisDataSource

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/catalog/DorisTable.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/catalog/DorisTable.scala
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.catalog
+
+import org.apache.doris.spark.config.DorisConfig
+import org.apache.doris.spark.read.DorisScanBuilder
+import org.apache.doris.spark.write.DorisWriteBuilder
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.WriteBuilder
+import org.apache.spark.sql.types.StructType
+
+class DorisTable(identifier: Identifier, config: DorisConfig, schema: Option[StructType])
+  extends DorisTableBase(identifier, config, schema) {
+
+  override def createScanBuilder(config: DorisConfig, schema: StructType): ScanBuilder = new DorisScanBuilder(config, schema)
+  override protected def createWriteBuilder(config: DorisConfig, schema: StructType): WriteBuilder = new DorisWriteBuilder(config, schema)
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/catalog/DorisTableCatalog.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/catalog/DorisTableCatalog.scala
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.catalog
+
+import org.apache.doris.spark.config.DorisConfig
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.types.StructType
+
+class DorisTableCatalog extends DorisTableCatalogBase {
+  override def dropNamespace(strings: Array[String], b: Boolean): Boolean = throw new UnsupportedOperationException()
+  override def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table =
+    new DorisTable(identifier, config, schema)
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/read/DorisScanBuilder.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/read/DorisScanBuilder.scala
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.doris.spark.read.expression.V2ExpressionBuilder
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.read.{Scan, SupportsPushDownLimit, SupportsPushDownV2Filters}
+import org.apache.spark.sql.types.StructType
+
+class DorisScanBuilder(config: DorisConfig, schema: StructType) extends DorisScanBuilderBase(config, schema)
+  with SupportsPushDownV2Filters
+  with SupportsPushDownLimit {
+
+  private var pushDownPredicates: Array[Predicate] = Array[Predicate]()
+
+  private val expressionBuilder = new V2ExpressionBuilder(config.getValue(DorisOptions.DORIS_FILTER_QUERY_IN_MAX_COUNT))
+
+  private var limitSize: Int = -1
+
+  override def build(): Scan = new DorisScanV2(config, readSchema, pushDownPredicates, limitSize)
+
+  override def pushPredicates(predicates: Array[Predicate]): Array[Predicate] = {
+    val (pushed, unsupported) = predicates.partition(predicate => {
+      expressionBuilder.buildOpt(predicate).isDefined
+    })
+    this.pushDownPredicates = pushed
+    unsupported
+  }
+
+  override def pushedPredicates(): Array[Predicate] = pushDownPredicates
+
+  override def pushLimit(i: Int): Boolean = {
+    limitSize = i
+    true
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/read/DorisScanV2.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/read/DorisScanV2.scala
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read
+
+import org.apache.doris.spark.config.{DorisConfig, DorisOptions}
+import org.apache.doris.spark.read.expression.V2ExpressionBuilder
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.types.StructType
+
+class DorisScanV2(config: DorisConfig, schema: StructType, filters: Array[Predicate], limit: Int) extends AbstractDorisScan(config, schema) with Logging {
+  override protected def compiledFilters(): Array[String] = {
+    val inValueLengthLimit = config.getValue(DorisOptions.DORIS_FILTER_QUERY_IN_MAX_COUNT)
+    val v2ExpressionBuilder = new V2ExpressionBuilder(inValueLengthLimit)
+    filters.map(e => v2ExpressionBuilder.buildOpt(e)).filter(_.isDefined).map(_.get)
+  }
+
+  override protected def getLimit: Int = limit
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilder.scala
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.read.expression
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.connector.expressions.filter.{AlwaysFalse, AlwaysTrue, And, Not, Or}
+import org.apache.spark.sql.connector.expressions.{Expression, GeneralScalarExpression, Literal, NamedReference}
+import org.apache.spark.sql.types.{DateType, TimestampType}
+
+import scala.util.{Failure, Success, Try}
+
+class V2ExpressionBuilder(inValueLengthLimit: Int) extends Logging {
+
+  def buildOpt(predicate: Expression): Option[String] = {
+    Try {
+      Some(build(predicate))
+    } match {
+      case Success(value) => value
+      case Failure(exception) =>
+        logWarning(s"Failed to build expression: ${predicate.toString}, and not support predicate push down, errMsg is ${exception.getMessage}")
+        None
+    }
+  }
+
+  def build(predicate: Expression): String = {
+    predicate match {
+      case and: And => s"(${build(and.left())} AND ${build(and.right())})"
+      case or: Or => s"(${build(or.left())} OR ${build(or.right())})"
+      case not: Not =>
+        not.child().name() match {
+          case "IS_NULL" => build(new GeneralScalarExpression("IS_NOT_NULL", not.children()(0).children()))
+          case "=" => build(new GeneralScalarExpression("!=", not.children()(0).children()))
+          case _ => s"NOT (${build(not.child())})"
+        }
+      case _: AlwaysTrue => "1=1"
+      case _: AlwaysFalse => "1=0"
+      case expr: Expression =>
+        expr match {
+          case literal: Literal[_] => visitLiteral(literal)
+          case namedRef: NamedReference => s"`${namedRef.toString}`"
+          case e: GeneralScalarExpression => e.name() match {
+            case "IN" =>
+              val expressions = e.children()
+              if (expressions.nonEmpty && expressions.length <= inValueLengthLimit) {
+                s"""${build(expressions(0))} IN (${expressions.slice(1, expressions.length).map(build).mkString(",")})"""
+              } else throw new IllegalArgumentException(s"exceeding limit of IN values: actual size ${expressions.length}, limit size $inValueLengthLimit")
+            case "IS_NULL" => s"${build(e.children()(0))} IS NULL"
+            case "IS_NOT_NULL" => s"${build(e.children()(0))} IS NOT NULL"
+            case "STARTS_WITH" => visitStartWith(build(e.children()(0)), build(e.children()(1)));
+            case "ENDS_WITH" => visitEndWith(build(e.children()(0)), build(e.children()(1)));
+            case "CONTAINS" => visitContains(build(e.children()(0)), build(e.children()(1)));
+            case "=" => s"${build(e.children()(0))} = ${build(e.children()(1))}"
+            case "!=" | "<>" => s"${build(e.children()(0))} != ${build(e.children()(1))}"
+            case "<" => s"${build(e.children()(0))} < ${build(e.children()(1))}"
+            case "<=" => s"${build(e.children()(0))} <= ${build(e.children()(1))}"
+            case ">" => s"${build(e.children()(0))} > ${build(e.children()(1))}"
+            case ">=" => s"${build(e.children()(0))} >= ${build(e.children()(1))}"
+            case "CASE_WHEN" =>
+              val fragment = new StringBuilder("CASE ")
+              val expressions = e.children()
+
+              for(i<- 0 until expressions.size - 1 by 2){
+                fragment.append(s" WHEN ${build(expressions(i))} THEN ${build(expressions(i+1))} ")
+              }
+
+              if (expressions.length % 2 != 0) {
+                val last = expressions(expressions.length - 1)
+                fragment.append(s" ELSE ${build(last)} ")
+              }
+              fragment.append(" END")
+
+              fragment.mkString
+            case _ => throw new IllegalArgumentException(s"Unsupported expression: ${e.name()}")
+          }
+        }
+    }
+  }
+
+  def visitLiteral(literal: Literal[_]): String = {
+    if (literal.value() == null) {
+      return "null"
+    }
+    literal.dataType() match {
+      case DateType => s"'${DateTimeUtils.toJavaDate(literal.value().asInstanceOf[Int]).toString}'"
+      case TimestampType => s"'${DateTimeUtils.toJavaTimestamp(literal.value().asInstanceOf[Long]).toString}'"
+      case _ => literal.toString
+    }
+  }
+  def visitStartWith(l: String, r: String): String = {
+    val value = r.substring(1, r.length - 1)
+    s"$l LIKE '$value%'"
+  }
+
+  def visitEndWith(l: String, r: String): String = {
+    val value = r.substring(1, r.length - 1)
+    s"$l LIKE '%$value'"
+  }
+
+  def visitContains(l: String, r: String): String = {
+    val value = r.substring(1, r.length - 1)
+    s"$l LIKE '%$value%'"
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/main/scala/org/apache/doris/spark/sql/sources/DorisDataSource.scala
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.sql.sources
+
+import org.apache.doris.spark.catalog.{DorisTable, DorisTableProviderBase}
+import org.apache.doris.spark.config.DorisConfig
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
+import org.apache.spark.sql.types.StructType
+
+class DorisDataSource extends DorisTableProviderBase with DorisSourceRegisterTrait with DorisSourceProvider with Serializable {
+
+  override def newTableInstance(identifier: Identifier, config: DorisConfig, schema: Option[StructType]): Table =
+    new DorisTable(identifier, config, schema)
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/test/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilderTest.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/test/scala/org/apache/doris/spark/read/expression/V2ExpressionBuilderTest.scala
@@ -1,0 +1,65 @@
+package org.apache.doris.spark.read.expression
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.spark.sql.ExpressionUtil
+import org.apache.spark.sql.sources._
+import org.junit.jupiter.api.{Assertions, Test}
+
+class V2ExpressionBuilderTest {
+
+  @Test
+  def buildTest(): Unit = {
+
+    val builder = new V2ExpressionBuilder(10)
+    Assertions.assertEquals(builder.build(EqualTo("c0", 1).toV2), "`c0` = 1")
+    Assertions.assertEquals(builder.build(Not(EqualTo("c1", 2)).toV2), "`c1` != 2")
+    Assertions.assertEquals(builder.build(GreaterThan("c2", 3.4).toV2), "`c2` > 3.4")
+    Assertions.assertEquals(builder.build(GreaterThanOrEqual("c3", 5.6).toV2), "`c3` >= 5.6")
+    Assertions.assertEquals(builder.build(LessThan("c4", 7.8).toV2), "`c4` < 7.8")
+    Assertions.assertEquals(builder.build(LessThanOrEqual("c5", BigDecimal(9.1011)).toV2), "`c5` <= 9.1011")
+    Assertions.assertEquals(builder.build(StringStartsWith("c6","a").toV2), "`c6` LIKE 'a%'")
+    Assertions.assertEquals(builder.build(StringEndsWith("c7", "b").toV2), "`c7` LIKE '%b'")
+    Assertions.assertEquals(builder.build(StringContains("c8", "c").toV2), "`c8` LIKE '%c%'")
+    Assertions.assertEquals(builder.build(In("c9", Array(12,13,14)).toV2), "`c9` IN (12,13,14)")
+    Assertions.assertEquals(builder.build(IsNull("c10").toV2), "`c10` IS NULL")
+    Assertions.assertEquals(builder.build(Not(IsNull("c11")).toV2), "`c11` IS NOT NULL")
+    Assertions.assertEquals(builder.build(And(EqualTo("c12", 15), EqualTo("c13", 16)).toV2), "(`c12` = 15 AND `c13` = 16)")
+    Assertions.assertEquals(builder.build(Or(EqualTo("c14", 17), EqualTo("c15", 18)).toV2), "(`c14` = 17 OR `c15` = 18)")
+    Assertions.assertEquals(builder.build(AlwaysTrue.toV2), "1=1")
+    Assertions.assertEquals(builder.build(AlwaysFalse.toV2), "1=0")
+    Assertions.assertEquals(builder.build(In("c19", Array(19,20,21,22,23,24,25,26)).toV2), "`c19` IN (19,20,21,22,23,24,25,26)")
+    Assertions.assertEquals(builder.build(In("c19", Array("19","20")).toV2), "`c19` IN ('19','20')")
+    val inException = Assertions.assertThrows(classOf[IllegalArgumentException], () => builder.build(In("c19", Array(19,20,21,22,23,24,25,26,27,28,29)).toV2))
+    Assertions.assertEquals(inException.getMessage, "exceeding limit of IN values: actual size 12, limit size 10")
+    val exception = Assertions.assertThrows(classOf[IllegalArgumentException], () => builder.build(ExpressionUtil.buildCoalesceFilter()))
+    Assertions.assertEquals(exception.getMessage, "Unsupported expression: COALESCE")
+
+  }
+
+  @Test
+  def buildOptTest() : Unit = {
+
+    val builder = new V2ExpressionBuilder(10)
+    Assertions.assertEquals(builder.buildOpt(EqualTo("c0", 1).toV2), Some("`c0` = 1"))
+    Assertions.assertEquals(builder.buildOpt(Not(EqualTo("c1", 2)).toV2), Some("`c1` != 2"))
+    Assertions.assertEquals(builder.buildOpt(GreaterThan("c2", 3.4).toV2), Some("`c2` > 3.4"))
+    Assertions.assertEquals(builder.buildOpt(ExpressionUtil.buildCoalesceFilter()), None)
+  }
+
+}

--- a/spark-doris-connector/spark-doris-connector-spark-4.0/src/test/scala/org/apache/spark/sql/ExpressionUtil.scala
+++ b/spark-doris-connector/spark-doris-connector-spark-4.0/src/test/scala/org/apache/spark/sql/ExpressionUtil.scala
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.connector.expressions.filter.Predicate
+import org.apache.spark.sql.connector.expressions.{Expression, FieldReference, GeneralScalarExpression, LiteralValue}
+import org.apache.spark.sql.types.StringType
+
+object ExpressionUtil {
+
+  def buildCoalesceFilter(): Expression = {
+    val gse = new GeneralScalarExpression("COALESCE", Array(FieldReference(Seq("A4")), LiteralValue("null", StringType)))
+    new Predicate("=", Array(gse, LiteralValue("1", StringType)))
+  }
+}

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -61,5 +61,15 @@ ${MVN} clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10
 echo "Deploying spark3.5..."
 ${MVN} clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10 -Pspark-3.5 -pl spark-doris-connector-spark-3.5 -am
 
+# Spark 4.x requires JDK 17 and Scala 2.13 (the modules above target JDK 8). Set JAVA17_HOME to a
+# JDK 17 home to deploy them with the right toolchain; otherwise the current JAVA_HOME must be JDK 17.
+SPARK4_MVN_ENV=""
+if [ -n "${JAVA17_HOME:-}" ]; then
+    SPARK4_MVN_ENV="JAVA_HOME=${JAVA17_HOME}"
+fi
+
+echo "Deploying spark4.0..."
+env ${SPARK4_MVN_ENV} ${MVN} clean deploy -Papache-release -DskipTests -DretryFailedDeploymentCount=10 -Pspark-4.0 -pl spark-doris-connector-spark-4.0 -am
+
 echo "Deploy jar finished."
 cd ${CURR_DIR}


### PR DESCRIPTION
## Summary

Adds Apache Spark 4.0 support (JDK 17, Scala 2.13) with full unit + integration + E2E coverage. The shared `base` module now cross-builds Scala 2.12 (Spark 2.4/3.x) and 2.13 (Spark 4.x).

> **Stacked on #364.** The Spark 4.0 failover IT (`testFailoverForRetry`) needs the exactly-once fix in #364, so this PR is based on it — please review/merge #364 first. After it merges, this branch is rebased onto master.

## New modules

- `spark-doris-connector-spark-4-base` — shared Spark 4 DataSource V2 base (fork of `spark-3-base`)
- `spark-doris-connector-spark-4.0` — Spark 4.0.0 / Scala 2.13.16 adapter

## Scala 2.13 readiness in `base` (still builds on 2.12)

`DorisRow` inherits Spark's `Row.toSeq` default; `DorisRelation`, `DorisArrowUtils`, and spark-4-base `DorisTableBase` build `StructType` from an `Array`; the affected test uses a `List`.

## Dependency alignment for Spark 4

Bumped per-profile (via properties) so the arrow-flight-sql read path works under Spark 4. **Spark 2.x/3.x are unchanged.**

| Dependency | 2.x / 3.x | Spark 4.0 |
| --- | --- | --- |
| Arrow | 15.0.2 | 18.1.0 |
| arrow-adbc (flight) | 0.14.0 | 0.18.0 |
| gRPC | 1.60.0 | 1.65.0 |
| protobuf | 3.22.3 | 3.25.1 |

The `spark-4.0` profile also adds Spark 4's JDK-17 `--add-opens` set (Arrow off-heap, date/time decoding, Catalyst codegen).

## Retry interval fix (Bug 1)

`Retry.exec` waited with a single `LockSupport.parkNanos`, which can return early on `unpark`. The stream-load processor interrupts the task thread on an async failure, and an interrupt also unparks a parked thread, so under Spark 4.x the retry interval collapsed to a few milliseconds and broke failover. Switched to `Thread.sleep` (immune to `unpark`) in a deadline loop. The exactly-once half of the failover story is #364.

## Build / release / CI

- **root pom** — new modules, `dependencyManagement`, `spark-4.0` profile
- **build.sh** — Scala 2.13 + Spark 4.0 options; require JDK 17 + Scala 2.13 for Spark 4.x
- **build-extension.yml** — JDK-17 job building + unit-testing the Spark 4.x modules
- **run-itcase.yml / run-e2ecase.yml** — JDK-17 jobs running ITCases / E2ECases for Spark 4.0
- **it module** — `spark-4-it` profile; slf4j-1.7 scoped to the 2.x/3.x profiles
- **deploy_staging_jars.sh** — stage-deploy spark-4.0 under JDK 17

## Test plan

- [x] Build + unit tests for the Spark 4.x modules (JDK 17)
- [x] Full Spark 4.0 integration suite (56 ITCase) + E2E — green locally and on CI
- [x] No regression to the 2.4/3.x builds (per-profile overrides; shared-base edits are behavior-preserving)
