### PR TITLE
[Fix](write) Make stream load retry exactly-once by reusing the label

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/StreamLoadResponse.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/entity/StreamLoadResponse.java
@@ -93,6 +93,14 @@ public class StreamLoadResponse {
         return Status;
     }
 
+    /**
+     * When {@link #getStatus()} is "Label Already Exists", the state of the load that already used
+     * the label: "FINISHED" (committed/visible), "PRECOMMITTED", or "RUNNING" (still in flight).
+     */
+    public String getExistingJobStatus() {
+        return ExistingJobStatus;
+    }
+
     public String getMessage() {
         return Message;
     }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -93,7 +93,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     private transient ExecutorService executor;
 
     private Future<StreamLoadResponse> requestFuture = null;
-    private volatile String currentLabel;
+    // Owns the stream-load label across batches; reuses the label on a retry so the backend can
+    // deduplicate a batch that already committed (exactly-once on retry).
+    private final StreamLoadLabelManager labelManager;
     private Exception unexpectedException = null;
 
     public AbstractStreamLoadProcessor(DorisConfig config) throws Exception {
@@ -110,6 +112,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         this.properties = config.getSinkProperties();
         // init stream load props
         this.isTwoPhaseCommitEnabled = config.getValue(DorisOptions.DORIS_SINK_ENABLE_2PC);
+        this.labelManager = new StreamLoadLabelManager(isTwoPhaseCommitEnabled);
         this.format = DataFormat.valueOf(properties.getOrDefault("format", "csv").toUpperCase());
         // enable gzip compression by default for non-arrow formats
         if (!DataFormat.ARROW.equals(format)) {
@@ -168,7 +171,8 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                 writeTo(toArrowFormat(rs));
             }
             output.close();
-            logger.info("stream load stopped with {}", currentLabel != null ? currentLabel : "group commit");
+            logger.info("stream load stopped with {}",
+                    labelManager.currentLabel() != null ? labelManager.currentLabel() : "group commit");
 
             StreamLoadResponse response;
             try {
@@ -177,11 +181,15 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                     throw new StreamLoadException("response is null");
                 }
             } catch (Exception e) {
+                // Batch failed: keep the current label so the retry reuses it (dedup-safe).
+                labelManager.onBatchFailed();
                 if (unexpectedException != null) {
                     throw unexpectedException;
                 }
                 throw new StreamLoadException("stream load stop failed", e);
             }
+            // Batch committed: the next batch must use a fresh label.
+            labelManager.onBatchCommitted();
             return isTwoPhaseCommitEnabled ? String.valueOf(response.getTxnId()) : null;
         }
         return null;
@@ -326,8 +334,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     private void handleStreamLoadProperties(HttpPut httpPut) throws OptionRequiredException {
         addCommonHeaders(httpPut);
         if (groupCommit == null || groupCommit.equals("off_mode")) {
-            currentLabel = generateStreamLoadLabel();
-            httpPut.setHeader("label", currentLabel);
+            // Reuse the previous label when retrying a failed batch so the backend can dedup it;
+            // otherwise mint a fresh label for a new batch.
+            httpPut.setHeader("label", labelManager.labelForNextBatch(this::generateStreamLoadLabel));
         }
         String writeFields = getWriteFields();
         httpPut.setHeader("columns", writeFields);
@@ -398,9 +407,11 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         }
         httpPut.setEntity(entity);
         Thread currentThread = Thread.currentThread();
+        // Captured for the async task: whether this batch reuses a prior (failed) batch's label.
+        final boolean labelReused = labelManager.isReusingLabel();
 
         logger.info("table {}.{} stream load started for {} on host {}:{}", database, table,
-                currentLabel != null ? currentLabel : "group commit", host, port);
+                labelManager.currentLabel() != null ? labelManager.currentLabel() : "group commit", host, port);
         return getExecutors().submit(() -> {
             StreamLoadResponse streamLoadResponse = null;
             try (CloseableHttpResponse response = client.execute(httpPut)) {
@@ -418,10 +429,18 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                         || streamLoadResponse.getMessage() == null) {
                     throw new StreamLoadException("stream load failed, response error : " + entityStr);
                 } else if (!streamLoadResponse.isSuccess()) {
-                    throw new StreamLoadException(
-                            "stream load failed, txnId: " + streamLoadResponse.getTxnId()
-                                    + ", status: " + streamLoadResponse.getStatus()
-                                    + ", msg: " + streamLoadResponse.getMessage());
+                    if (StreamLoadLabelManager.isAlreadyCommitted(labelReused, streamLoadResponse.getStatus(),
+                            streamLoadResponse.getExistingJobStatus())) {
+                        // The batch we are retrying already committed under this reused label, so
+                        // Doris rejects the duplicate. The rows are already present — treat the
+                        // retry as a success instead of writing them twice (exactly-once on retry).
+                        logger.info("reused label {} already committed; retry is a no-op", labelManager.currentLabel());
+                    } else {
+                        throw new StreamLoadException(
+                                "stream load failed, txnId: " + streamLoadResponse.getTxnId()
+                                        + ", status: " + streamLoadResponse.getStatus()
+                                        + ", msg: " + streamLoadResponse.getMessage());
+                    }
                 }
             } catch (Exception e) {
                 logger.error("stream load exception", e);

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -96,6 +96,11 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     // Owns the stream-load label across batches; reuses the label on a retry so the backend can
     // deduplicate a batch that already committed (exactly-once on retry).
     private final StreamLoadLabelManager labelManager;
+    // Whether the in-flight batch's commit outcome is unknown (e.g. a lost response or interrupt), so
+    // a retry must reuse the label to let the backend dedup a possible prior commit. A definite
+    // rejection — most importantly a fresh-label "Label Already Exists" collision — sets this false so
+    // the retry mints a new label instead of reusing the colliding one.
+    private volatile boolean batchCommitOutcomeUnknown = true;
     private Exception unexpectedException = null;
 
     public AbstractStreamLoadProcessor(DorisConfig config) throws Exception {
@@ -181,8 +186,10 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                     throw new StreamLoadException("response is null");
                 }
             } catch (Exception e) {
-                // Batch failed: keep the current label so the retry reuses it (dedup-safe).
-                labelManager.onBatchFailed();
+                // Batch failed: reuse the label on the retry only when the commit outcome is unknown
+                // (a possibly-committed batch must be deduped). A definite rejection — e.g. a
+                // fresh-label collision — keeps a fresh label so we don't mask another load as ours.
+                labelManager.onBatchFailed(batchCommitOutcomeUnknown);
                 if (unexpectedException != null) {
                     throw unexpectedException;
                 }
@@ -389,6 +396,8 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     protected abstract String generateStreamLoadLabel() throws OptionRequiredException;
 
     private Future<StreamLoadResponse> buildReqAndExec(String host, Integer port, CloseableHttpClient client) {
+        // New batch attempt: assume the outcome is unknown until a definite rejection proves otherwise.
+        batchCommitOutcomeUnknown = true;
         HttpPut httpPut = new HttpPut(URLs.streamLoad(host, port, database, table, isHttpsEnabled));
         try {
             handleStreamLoadProperties(httpPut);
@@ -436,6 +445,13 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                         // retry as a success instead of writing them twice (exactly-once on retry).
                         logger.info("reused label {} already committed; retry is a no-op", labelManager.currentLabel());
                     } else {
+                        if (StreamLoadLabelManager.isFreshLabelCollision(labelReused, streamLoadResponse.getStatus())) {
+                            // A freshly minted label already exists on the backend — a definite
+                            // rejection (the label belongs to another load), not a lost response. Keep
+                            // a fresh label on the retry; reusing this one could mask that other load's
+                            // commit as ours and silently drop this batch's rows.
+                            batchCommitOutcomeUnknown = false;
+                        }
                         throw new StreamLoadException(
                                 "stream load failed, txnId: " + streamLoadResponse.getTxnId()
                                         + ", status: " + streamLoadResponse.getStatus()

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/StreamLoadLabelManager.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/StreamLoadLabelManager.java
@@ -89,13 +89,22 @@ class StreamLoadLabelManager implements Serializable {
     }
 
     /**
-     * The previous batch failed: reuse the same label on the retry so the backend can deduplicate it.
-     * Only applies to auto-commit loads; 2PC loads always get a fresh label.
+     * The previous batch failed. Reuse the same label on the retry ONLY when the batch's commit
+     * outcome is unknown (e.g. a lost response or an interrupt): the batch may have actually
+     * committed on the backend, so reusing the label lets the backend reject the retry as a
+     * duplicate.
+     *
+     * <p>A definite rejection must NOT reuse the label — in particular a fresh-label
+     * "Label Already Exists" collision, whose existing FINISHED load belongs to a different batch.
+     * Reusing it would let {@link #isAlreadyCommitted} mask that other load as this batch's success
+     * and silently drop this batch's rows; instead the next attempt mints a fresh label. Only
+     * applies to auto-commit loads; 2PC loads always get a fresh label.
+     *
+     * @param commitOutcomeUnknown whether the failure left the batch's commit outcome unknown (so it
+     *                             may have committed and the retry must reuse the label to dedup)
      */
-    void onBatchFailed() {
-        if (!twoPhaseCommitEnabled) {
-            reuseLabel = true;
-        }
+    void onBatchFailed(boolean commitOutcomeUnknown) {
+        reuseLabel = !twoPhaseCommitEnabled && commitOutcomeUnknown;
     }
 
     /**
@@ -110,5 +119,15 @@ class StreamLoadLabelManager implements Serializable {
         return labelReused
                 && LABEL_ALREADY_EXISTS_STATUS.equalsIgnoreCase(status)
                 && EXISTING_JOB_FINISHED.equalsIgnoreCase(existingJobStatus);
+    }
+
+    /**
+     * Whether a failed-load response is a fresh-label "Label Already Exists" collision: the label was
+     * freshly minted (not reused) yet already exists on the backend, so it belongs to a different
+     * load. This is a definite rejection of this batch — the commit outcome is known (rejected), not
+     * unknown — so it must NOT enable label reuse; the retry mints a new label instead.
+     */
+    static boolean isFreshLabelCollision(boolean labelReused, String status) {
+        return !labelReused && LABEL_ALREADY_EXISTS_STATUS.equalsIgnoreCase(status);
     }
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/StreamLoadLabelManager.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/StreamLoadLabelManager.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.client.write;
+
+import org.apache.doris.spark.exception.OptionRequiredException;
+
+import java.io.Serializable;
+
+/**
+ * Owns the stream-load label across batches so that a retry of a failed batch can reuse the previous
+ * label.
+ *
+ * <p>An auto-commit (non-2PC) batch that fails on the client side may have actually committed on the
+ * backend (e.g. its HTTP response was lost). Reusing the same label on the retry lets the backend
+ * reject the retry as a duplicate, so the rows are written exactly once instead of twice. A fresh
+ * label is minted for every new (committed) batch, so normal writes are unaffected.
+ *
+ * <p>Two-phase-commit loads do NOT reuse labels: their exactly-once guarantee comes from the
+ * precommit/commit protocol (a retry begins a fresh transaction and the orphaned precommitted one
+ * aborts), and a reused-label collision carries no usable transaction id.
+ */
+class StreamLoadLabelManager implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Backend status returned when a label has already been used by another load. */
+    static final String LABEL_ALREADY_EXISTS_STATUS = "Label Already Exists";
+
+    /**
+     * {@code ExistingJobStatus} value meaning the load that already used the label has COMMITTED.
+     * Other values ("RUNNING", "PRECOMMITTED") mean the original is still in flight and may yet
+     * abort, so they must NOT be treated as a successful no-op.
+     */
+    static final String EXISTING_JOB_FINISHED = "FINISHED";
+
+    /** Generates a fresh label; may fail when a required option is missing. */
+    @FunctionalInterface
+    interface LabelGenerator {
+        String generate() throws OptionRequiredException;
+    }
+
+    private final boolean twoPhaseCommitEnabled;
+    private volatile String currentLabel;
+    private boolean reuseLabel = false;
+
+    StreamLoadLabelManager(boolean twoPhaseCommitEnabled) {
+        this.twoPhaseCommitEnabled = twoPhaseCommitEnabled;
+    }
+
+    /**
+     * Returns the label to use for the next batch: the current label when retrying a failed batch,
+     * otherwise a freshly generated one.
+     */
+    String labelForNextBatch(LabelGenerator generator) throws OptionRequiredException {
+        if (!reuseLabel || currentLabel == null) {
+            currentLabel = generator.generate();
+        }
+        return currentLabel;
+    }
+
+    /** The label of the most recently started batch (may be {@code null} before the first batch). */
+    String currentLabel() {
+        return currentLabel;
+    }
+
+    /** Whether the current batch is reusing a previous (failed) batch's label. */
+    boolean isReusingLabel() {
+        return reuseLabel;
+    }
+
+    /** The previous batch committed: the next batch must use a fresh label. */
+    void onBatchCommitted() {
+        reuseLabel = false;
+    }
+
+    /**
+     * The previous batch failed: reuse the same label on the retry so the backend can deduplicate it.
+     * Only applies to auto-commit loads; 2PC loads always get a fresh label.
+     */
+    void onBatchFailed() {
+        if (!twoPhaseCommitEnabled) {
+            reuseLabel = true;
+        }
+    }
+
+    /**
+     * Whether a failed-load response means the (reused) label's load already COMMITTED — i.e. the
+     * retry is an idempotent no-op and the rows are already present, so it can be treated as success.
+     *
+     * <p>Requires both that we are retrying with a reused label and that the backend reports the
+     * existing job as FINISHED. A still-RUNNING/PRECOMMITTED original may still abort, so it stays a
+     * retriable failure rather than being masked as success (which would silently lose those rows).
+     */
+    static boolean isAlreadyCommitted(boolean labelReused, String status, String existingJobStatus) {
+        return labelReused
+                && LABEL_ALREADY_EXISTS_STATUS.equalsIgnoreCase(status)
+                && EXISTING_JOB_FINISHED.equalsIgnoreCase(existingJobStatus);
+    }
+}

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/StreamLoadLabelManagerTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/StreamLoadLabelManagerTest.java
@@ -71,7 +71,7 @@ public class StreamLoadLabelManagerTest {
         AtomicInteger seq = new AtomicInteger();
 
         String first = mgr.labelForNextBatch(counting(seq));
-        mgr.onBatchFailed();
+        mgr.onBatchFailed(true);
         Assertions.assertTrue(mgr.isReusingLabel());
 
         String retry = mgr.labelForNextBatch(counting(seq));
@@ -85,7 +85,7 @@ public class StreamLoadLabelManagerTest {
         AtomicInteger seq = new AtomicInteger();
 
         mgr.labelForNextBatch(counting(seq)); // label-0
-        mgr.onBatchFailed();
+        mgr.onBatchFailed(true);
         mgr.labelForNextBatch(counting(seq)); // reuse label-0
         mgr.onBatchCommitted();               // retry committed
         String next = mgr.labelForNextBatch(counting(seq));
@@ -102,7 +102,7 @@ public class StreamLoadLabelManagerTest {
         AtomicInteger seq = new AtomicInteger();
 
         String first = mgr.labelForNextBatch(counting(seq));
-        mgr.onBatchFailed();
+        mgr.onBatchFailed(true);
         Assertions.assertFalse(mgr.isReusingLabel(), "2PC must not reuse labels");
 
         String retry = mgr.labelForNextBatch(counting(seq));
@@ -116,7 +116,7 @@ public class StreamLoadLabelManagerTest {
         // executors, so the manager must stay Serializable and round-trip its state.
         StreamLoadLabelManager mgr = autoCommit();
         mgr.labelForNextBatch(counting(new AtomicInteger())); // label-0
-        mgr.onBatchFailed();
+        mgr.onBatchFailed(true);
 
         byte[] bytes;
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -149,5 +149,35 @@ public class StreamLoadLabelManagerTest {
         // Any other failure status is a real error even on a reused label.
         Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, "Fail", "FINISHED"));
         Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, null, "FINISHED"));
+    }
+
+    @Test
+    public void definiteRejectKeepsAFreshLabel() throws Exception {
+        // A failure whose commit outcome is KNOWN-rejected (e.g. a fresh-label collision) must not
+        // reuse the label: reusing it could let a different load's FINISHED state be masked as this
+        // batch's success and drop the rows. The retry mints a fresh label instead.
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq)); // label-0
+        mgr.onBatchFailed(false);
+        Assertions.assertFalse(mgr.isReusingLabel(), "a definite rejection must not reuse the label");
+
+        String retry = mgr.labelForNextBatch(counting(seq));
+        Assertions.assertEquals("label-0", first);
+        Assertions.assertEquals("label-1", retry, "the retry must mint a fresh label");
+    }
+
+    @Test
+    public void freshLabelCollisionIsADefiniteReject() {
+        // A fresh (non-reused) label that already exists belongs to another load — a definite reject.
+        Assertions.assertTrue(StreamLoadLabelManager.isFreshLabelCollision(false, LABEL_EXISTS));
+        Assertions.assertTrue(StreamLoadLabelManager.isFreshLabelCollision(false, "label already exists"));
+
+        // A reused label hitting "Label Already Exists" is the dedup path, not a fresh collision.
+        Assertions.assertFalse(StreamLoadLabelManager.isFreshLabelCollision(true, LABEL_EXISTS));
+        // Any other failure status on a fresh label is not a label collision.
+        Assertions.assertFalse(StreamLoadLabelManager.isFreshLabelCollision(false, "Fail"));
+        Assertions.assertFalse(StreamLoadLabelManager.isFreshLabelCollision(false, null));
     }
 }

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/StreamLoadLabelManagerTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/StreamLoadLabelManagerTest.java
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.client.write;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class StreamLoadLabelManagerTest {
+
+    private static final String LABEL_EXISTS = "Label Already Exists";
+
+    /** A deterministic label generator producing label-0, label-1, ... */
+    private static StreamLoadLabelManager.LabelGenerator counting(AtomicInteger seq) {
+        return () -> "label-" + seq.getAndIncrement();
+    }
+
+    /** An auto-commit (non-2PC) manager — the mode that reuses labels. */
+    private static StreamLoadLabelManager autoCommit() {
+        return new StreamLoadLabelManager(false);
+    }
+
+    @Test
+    public void firstBatchGeneratesAFreshLabel() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        Assertions.assertNull(mgr.currentLabel());
+        Assertions.assertFalse(mgr.isReusingLabel());
+
+        String label = mgr.labelForNextBatch(counting(new AtomicInteger()));
+        Assertions.assertEquals("label-0", label);
+        Assertions.assertEquals("label-0", mgr.currentLabel());
+    }
+
+    @Test
+    public void committedBatchesEachGetAFreshLabel() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq));
+        mgr.onBatchCommitted();
+        String second = mgr.labelForNextBatch(counting(seq));
+
+        Assertions.assertEquals("label-0", first);
+        Assertions.assertEquals("label-1", second);
+        Assertions.assertFalse(mgr.isReusingLabel());
+    }
+
+    @Test
+    public void retryReusesTheFailedBatchLabel() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq));
+        mgr.onBatchFailed();
+        Assertions.assertTrue(mgr.isReusingLabel());
+
+        String retry = mgr.labelForNextBatch(counting(seq));
+        Assertions.assertEquals(first, retry, "retry must reuse the failed batch's label");
+        Assertions.assertEquals(1, seq.get(), "no new label should be generated on retry");
+    }
+
+    @Test
+    public void freshLabelResumesAfterASuccessfulRetry() throws Exception {
+        StreamLoadLabelManager mgr = autoCommit();
+        AtomicInteger seq = new AtomicInteger();
+
+        mgr.labelForNextBatch(counting(seq)); // label-0
+        mgr.onBatchFailed();
+        mgr.labelForNextBatch(counting(seq)); // reuse label-0
+        mgr.onBatchCommitted();               // retry committed
+        String next = mgr.labelForNextBatch(counting(seq));
+
+        Assertions.assertEquals("label-1", next);
+        Assertions.assertFalse(mgr.isReusingLabel());
+    }
+
+    @Test
+    public void twoPhaseCommitNeverReusesLabel() throws Exception {
+        // Under 2PC, a reused-label collision carries no usable txn id, so labels must stay fresh —
+        // exactly-once is handled by the precommit/commit protocol instead.
+        StreamLoadLabelManager mgr = new StreamLoadLabelManager(true);
+        AtomicInteger seq = new AtomicInteger();
+
+        String first = mgr.labelForNextBatch(counting(seq));
+        mgr.onBatchFailed();
+        Assertions.assertFalse(mgr.isReusingLabel(), "2PC must not reuse labels");
+
+        String retry = mgr.labelForNextBatch(counting(seq));
+        Assertions.assertEquals("label-0", first);
+        Assertions.assertEquals("label-1", retry, "2PC retry must get a fresh label");
+    }
+
+    @Test
+    public void isSerializableWithState() throws Exception {
+        // The Spark 2.x/3.x DorisWriter serializes the committer (which holds this manager) to the
+        // executors, so the manager must stay Serializable and round-trip its state.
+        StreamLoadLabelManager mgr = autoCommit();
+        mgr.labelForNextBatch(counting(new AtomicInteger())); // label-0
+        mgr.onBatchFailed();
+
+        byte[] bytes;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(mgr);
+            bytes = bos.toByteArray();
+        }
+        StreamLoadLabelManager restored;
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            restored = (StreamLoadLabelManager) ois.readObject();
+        }
+
+        Assertions.assertEquals("label-0", restored.currentLabel());
+        Assertions.assertTrue(restored.isReusingLabel());
+    }
+
+    @Test
+    public void alreadyCommittedOnlyForReusedLabelThatActuallyFinished() {
+        // The exactly-once no-op: a reused label whose existing load has COMMITTED (FINISHED).
+        Assertions.assertTrue(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, "FINISHED"));
+        Assertions.assertTrue(StreamLoadLabelManager.isAlreadyCommitted(true, "label already exists", "finished"));
+
+        // A still-in-flight original may yet abort — must NOT be masked as success (would lose data).
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, "RUNNING"));
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, "PRECOMMITTED"));
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, LABEL_EXISTS, null));
+
+        // A fresh-label collision is a real error, not a dedup no-op.
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(false, LABEL_EXISTS, "FINISHED"));
+        // Any other failure status is a real error even on a reused label.
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, "Fail", "FINISHED"));
+        Assertions.assertFalse(StreamLoadLabelManager.isAlreadyCommitted(true, null, "FINISHED"));
+    }
+}


### PR DESCRIPTION
## Problem

The stream load write path is not exactly-once across a client-side retry.

A batch that fails on the client side may have **actually committed** on the backend — e.g. its HTTP response is lost while the task thread is interrupted (the processor interrupts the task thread on an async failure), or a concurrent DDL races the load. Because every batch — including each retry — is sent with a **freshly generated label**, the backend cannot recognize the retry as a duplicate, so the rows are written twice.

## Fix

- Reuse the previous batch's label when retrying a **failed** batch. A fresh label is still minted for every new (committed) batch, so normal writes are unchanged.
- Treat a `Label Already Exists` response **on a reused label** as success: the original batch already committed under that label, so the retry is an idempotent no-op and the backend rejects the duplicate.

The label lifecycle (reuse-on-failure, fresh-on-commit, and the already-committed check) is encapsulated in a new `StreamLoadLabelManager`.

## Notes

The race is reliably reproducible under Spark 4.x (its task-thread unparking shortens the lost-response window); on Spark 2.x/3.x the same hole exists but is rare. It is exercised end-to-end by `DorisWriterFailoverITCase#testFailoverForRetry` under the Spark 4.0 module.

## Test plan

- [x] `StreamLoadLabelManagerTest` — unit tests for the label-reuse policy (reuse on retry, fresh on commit, "already committed" no-op)
- [x] `DorisWriterFailoverITCase` continues to pass on Spark 2.x/3.x
- [x] Exactly-once verified (no duplicate rows) via the Spark 4.0 integration suite
