### PR TITLE
[fix](stream-load) Add doris.sink.http.expect-continue option to control Expect header

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessor.java
@@ -88,6 +88,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
     private final DataFormat format;
     private final boolean isGzipCompressionEnabled;
     private final boolean isPassThrough;
+    private final boolean httpExpectContinue;
     private final List<R> recordBuffer = new LinkedList<>();
     private final int pipeSize;
     protected String columnSeparator;
@@ -139,6 +140,7 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
             groupCommit = properties.get(GROUP_COMMIT).toLowerCase();
         }
         this.isPassThrough = config.getValue(DorisOptions.DORIS_SINK_STREAMING_PASSTHROUGH);
+        this.httpExpectContinue = config.getValue(DorisOptions.DORIS_SINK_HTTP_EXPECT_CONTINUE);
         this.pipeSize = config.getValue(DorisOptions.DORIS_SINK_NET_BUFFER_SIZE);
     }
 
@@ -361,6 +363,9 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
                 break;
         }
         properties.forEach(httpPut::setHeader);
+        if (!httpExpectContinue) {
+            httpPut.removeHeaders(HttpHeaders.EXPECT);
+        }
     }
 
     private void handleCommitHeaders(HttpPut httpPut, String transactionId) throws OptionRequiredException {
@@ -379,7 +384,11 @@ public abstract class AbstractStreamLoadProcessor<R> extends DorisWriter<R> impl
         String user = config.getValue(DorisOptions.DORIS_USER);
         String password = config.getValue(DorisOptions.DORIS_PASSWORD);
         HttpUtils.setAuth(req, user, password);
-        req.setHeader(HttpHeaders.EXPECT, "100-continue");
+        if (httpExpectContinue) {
+            req.setHeader(HttpHeaders.EXPECT, "100-continue");
+        } else {
+            req.removeHeaders(HttpHeaders.EXPECT);
+        }
         req.setHeader(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
     }
 

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/config/DorisOptions.java
@@ -116,6 +116,16 @@ public class DorisOptions {
      */
     public static final ConfigOption<Boolean> DORIS_SINK_AUTO_REDIRECT = ConfigOptions.name("doris.sink.auto-redirect").booleanType().defaultValue(true).withDescription("");
 
+    /**
+     * Whether to send the HTTP {@code Expect: 100-continue} header for Stream Load requests.
+     * When disabled, the connector explicitly removes the header instead of setting an empty value.
+     */
+    public static final ConfigOption<Boolean> DORIS_SINK_HTTP_EXPECT_CONTINUE =
+            ConfigOptions.name("doris.sink.http.expect-continue")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("");
+
     public static final ConfigOption<Boolean> DORIS_ENABLE_TLS = ConfigOptions.name("doris.enable.tls").booleanType().defaultValue(false).withDescription("Enable one-way TLS for Doris client protocols.");
 
     public static final ConfigOption<String> DORIS_TLS_CA_CERTIFICATE_PATH = ConfigOptions.name("doris.tls.ca-certificate-path").stringType().defaultValue("").withDescription("Path to a PEM CA certificate chain. The JVM default truststore is used when empty.");

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessorTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/AbstractStreamLoadProcessorTest.java
@@ -21,10 +21,14 @@ import org.apache.doris.spark.config.DorisConfig;
 import org.apache.doris.spark.config.DorisOptions;
 import org.apache.doris.spark.rest.models.DataFormat;
 import org.apache.doris.spark.testutil.HttpsTestServer;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -61,6 +65,70 @@ public class AbstractStreamLoadProcessorTest {
                 processor.close();
             }
         }
+    }
+
+    @Test
+    public void expectContinueHeaderEnabledByDefault() throws Exception {
+        Map<String, String> values = new HashMap<>();
+        values.put(DorisOptions.DORIS_FENODES.getName(), "127.0.0.1:8030");
+        values.put(DorisOptions.DORIS_BENODES.getName(), "127.0.0.1:8040");
+        values.put(DorisOptions.DORIS_TABLE_IDENTIFIER.getName(), "db.tbl");
+        values.put(DorisOptions.DORIS_USER.getName(), "root");
+        values.put(DorisOptions.DORIS_PASSWORD.getName(), "");
+        values.put(DorisOptions.DORIS_SINK_AUTO_REDIRECT.getName(), "false");
+        DorisConfig config = DorisConfig.fromMap(values, false);
+        TestStreamLoadProcessor processor = new TestStreamLoadProcessor(config);
+        Method addCommonHeaders =
+                AbstractStreamLoadProcessor.class.getDeclaredMethod(
+                        "addCommonHeaders", HttpRequestBase.class);
+        addCommonHeaders.setAccessible(true);
+        HttpPut httpPut = new HttpPut("http://127.0.0.1:8040/");
+        addCommonHeaders.invoke(processor, httpPut);
+        Assert.assertEquals(
+                "100-continue", httpPut.getFirstHeader(HttpHeaders.EXPECT).getValue());
+    }
+
+    @Test
+    public void expectContinueHeaderDisabled() throws Exception {
+        Map<String, String> values = new HashMap<>();
+        values.put(DorisOptions.DORIS_FENODES.getName(), "127.0.0.1:8030");
+        values.put(DorisOptions.DORIS_BENODES.getName(), "127.0.0.1:8040");
+        values.put(DorisOptions.DORIS_TABLE_IDENTIFIER.getName(), "db.tbl");
+        values.put(DorisOptions.DORIS_USER.getName(), "root");
+        values.put(DorisOptions.DORIS_PASSWORD.getName(), "");
+        values.put(DorisOptions.DORIS_SINK_AUTO_REDIRECT.getName(), "false");
+        values.put(DorisOptions.DORIS_SINK_HTTP_EXPECT_CONTINUE.getName(), "false");
+        DorisConfig config = DorisConfig.fromMap(values, false);
+        TestStreamLoadProcessor processor = new TestStreamLoadProcessor(config);
+        Method addCommonHeaders =
+                AbstractStreamLoadProcessor.class.getDeclaredMethod(
+                        "addCommonHeaders", HttpRequestBase.class);
+        addCommonHeaders.setAccessible(true);
+        HttpPut httpPut = new HttpPut("http://127.0.0.1:8040/");
+        addCommonHeaders.invoke(processor, httpPut);
+        Assert.assertNull(httpPut.getFirstHeader(HttpHeaders.EXPECT));
+    }
+
+    @Test
+    public void disabledExpectContinueRemovesSinkPropertyExpect() throws Exception {
+        Map<String, String> values = new HashMap<>();
+        values.put(DorisOptions.DORIS_FENODES.getName(), "127.0.0.1:8030");
+        values.put(DorisOptions.DORIS_BENODES.getName(), "127.0.0.1:8040");
+        values.put(DorisOptions.DORIS_TABLE_IDENTIFIER.getName(), "db.tbl");
+        values.put(DorisOptions.DORIS_USER.getName(), "root");
+        values.put(DorisOptions.DORIS_PASSWORD.getName(), "");
+        values.put(DorisOptions.DORIS_SINK_AUTO_REDIRECT.getName(), "false");
+        values.put(DorisOptions.DORIS_SINK_HTTP_EXPECT_CONTINUE.getName(), "false");
+        values.put(DorisOptions.STREAM_LOAD_PROP_PREFIX + "expect", "disabled");
+        DorisConfig config = DorisConfig.fromMap(values, false);
+        TestStreamLoadProcessor processor = new TestStreamLoadProcessor(config);
+        Method handleStreamLoadProperties =
+                AbstractStreamLoadProcessor.class.getDeclaredMethod(
+                        "handleStreamLoadProperties", HttpPut.class);
+        handleStreamLoadProperties.setAccessible(true);
+        HttpPut httpPut = new HttpPut("http://127.0.0.1:8040/");
+        handleStreamLoadProperties.invoke(processor, httpPut);
+        Assert.assertNull(httpPut.getFirstHeader(HttpHeaders.EXPECT));
     }
 
     private static final class TestStreamLoadProcessor


### PR DESCRIPTION
## Problem

When the Spark Connector sends Stream Load requests with `PipedInputStream`/`InputStreamEntity`, the request uses chunked transfer encoding and the connector hard-codes the `Expect: 100-continue` header in `AbstractStreamLoadProcessor.addCommonHeaders`. On some Doris BE/libevent configurations this causes HTTP `413 Request Entity Too Large` or `417 Expectation Failed` errors.

Configuring `doris.sink.properties.expect` to an empty string, space, or `disabled` does not truly remove the header, because Java HttpClient treats a set header with an empty value differently from curl's `-H 'Expect:'` suppression.

Closes apache/doris-spark-connector#373.

## Solution

Add a typed option `doris.sink.http.expect-continue` (default `true` for backward compatibility).

- When the option is `true`, the connector behaves as before and sends `Expect: 100-continue`.
- When the option is `false`, the connector explicitly calls `req.removeHeaders(HttpHeaders.EXPECT)` so the header is truly absent from the HTTP request.
- After applying user-supplied stream-load properties (`doris.sink.properties.*`), the connector removes the header again when the option is disabled, ensuring no empty/placeholder `Expect` value is sent.

## Usage

```
.option("doris.sink.http.expect-continue", "false")
```

It is also recommended to set `doris.sink.auto-redirect=false` when writing to BE directly in environments where FE returns 307 redirects and the non-repeatable pipe stream would fail.

## Tests

- `expectContinueHeaderEnabledByDefault` – default `Expect: 100-continue` is set.
- `expectContinueHeaderDisabled` – the `Expect` header is absent when disabled.
- `disabledExpectContinueRemovesSinkPropertyExpect` – the option `false` overrides any `doris.sink.properties.expect` value and removes the header.

All three new tests plus the existing `AbstractStreamLoadProcessorTest` cases pass.
