### PR TITLE
[Fix] Recover DATETIME wall clock from Arrow timezone

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/RowBatch.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/RowBatch.java
@@ -450,7 +450,7 @@ public class RowBatch implements Serializable {
                                     addValueToRow(rowIndex, null);
                                     continue;
                                 }
-                                LocalDateTime dateTime = getDateTime(rowIndex, timeStampVector);
+                                LocalDateTime dateTime = getDateTime(rowIndex, timeStampVector, currentType);
                                 if (datetimeJava8ApiEnabled) {
                                     Instant instant = dateTime.atZone(DEFAULT_ZONE_ID).toInstant();
                                     addValueToRow(rowIndex, instant);
@@ -598,15 +598,39 @@ public class RowBatch implements Serializable {
     }
 
     public LocalDateTime getDateTime(int rowIndex, FieldVector fieldVector) {
+        return getDateTime(rowIndex, fieldVector, "DATETIME");
+    }
+
+    /**
+     * Decode an Arrow timestamp into a {@link LocalDateTime} of wall-clock digits.
+     *
+     * <p>Doris {@code DATETIME} / {@code DATETIMEV2} store naive wall-clock values. Some
+     * backends still emit timezone-aware Arrow timestamps (for example {@code +08:00}).
+     * In that case the epoch instant plus the Arrow timezone recover the original digits.
+     * {@code TIMESTAMPTZ} is a true instant, so it stays in the JVM default zone.
+     *
+     * <p>When the Arrow timezone is absent, the vector is treated as a naive timestamp
+     * ({@code getObject()} when that returns {@link LocalDateTime}).
+     */
+    public LocalDateTime getDateTime(int rowIndex, FieldVector fieldVector, String dorisType) {
         TimeStampVector vector = (TimeStampVector) fieldVector;
         if (vector.isNull(rowIndex)) {
             return null;
         }
         ArrowType.Timestamp timestampType = (ArrowType.Timestamp) vector.getField().getType();
-        if (timestampType.getTimezone() == null) {
-            return (LocalDateTime) vector.getObject(rowIndex);
+        String tz = timestampType.getTimezone();
+        if (tz == null || tz.trim().isEmpty()) {
+            Object value = vector.getObject(rowIndex);
+            if (value instanceof LocalDateTime) {
+                return (LocalDateTime) value;
+            }
+            return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), DEFAULT_ZONE_ID);
         }
-        return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), DEFAULT_ZONE_ID);
+        ZoneId arrowZone = ZoneId.of(tz);
+        if ("TIMESTAMPTZ".equalsIgnoreCase(dorisType)) {
+            return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), DEFAULT_ZONE_ID);
+        }
+        return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), arrowZone);
     }
 
     public static String completeMilliseconds(String stringValue) {

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/RowBatch.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/read/RowBatch.java
@@ -598,39 +598,26 @@ public class RowBatch implements Serializable {
     }
 
     public LocalDateTime getDateTime(int rowIndex, FieldVector fieldVector) {
-        return getDateTime(rowIndex, fieldVector, "DATETIME");
+        return getDateTime(rowIndex, fieldVector, null);
     }
 
-    /**
-     * Decode an Arrow timestamp into a {@link LocalDateTime} of wall-clock digits.
-     *
-     * <p>Doris {@code DATETIME} / {@code DATETIMEV2} store naive wall-clock values. Some
-     * backends still emit timezone-aware Arrow timestamps (for example {@code +08:00}).
-     * In that case the epoch instant plus the Arrow timezone recover the original digits.
-     * {@code TIMESTAMPTZ} is a true instant, so it stays in the JVM default zone.
-     *
-     * <p>When the Arrow timezone is absent, the vector is treated as a naive timestamp
-     * ({@code getObject()} when that returns {@link LocalDateTime}).
-     */
-    public LocalDateTime getDateTime(int rowIndex, FieldVector fieldVector, String dorisType) {
+    private LocalDateTime getDateTime(int rowIndex, FieldVector fieldVector, String dorisType) {
         TimeStampVector vector = (TimeStampVector) fieldVector;
         if (vector.isNull(rowIndex)) {
             return null;
         }
         ArrowType.Timestamp timestampType = (ArrowType.Timestamp) vector.getField().getType();
         String tz = timestampType.getTimezone();
-        if (tz == null || tz.trim().isEmpty()) {
-            Object value = vector.getObject(rowIndex);
-            if (value instanceof LocalDateTime) {
-                return (LocalDateTime) value;
-            }
-            return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), DEFAULT_ZONE_ID);
+        if (tz == null) {
+            return (LocalDateTime) vector.getObject(rowIndex);
         }
-        ZoneId arrowZone = ZoneId.of(tz);
-        if ("TIMESTAMPTZ".equalsIgnoreCase(dorisType)) {
-            return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), DEFAULT_ZONE_ID);
+        // DATETIME is timezone-agnostic. Some Doris versions still attach an Arrow timezone
+        // (apache/doris#38215). Decode in that zone so the LocalDateTime matches stored digits.
+        // TIMESTAMPTZ keeps the instant in the JVM default zone (apache/doris-spark-connector#366).
+        if ("DATETIME".equals(dorisType) || "DATETIMEV2".equals(dorisType)) {
+            return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), ZoneId.of(tz));
         }
-        return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), arrowZone);
+        return longToLocalDateTime(vector.get(rowIndex), timestampType.getUnit(), DEFAULT_ZONE_ID);
     }
 
     public static String completeMilliseconds(String stringValue) {

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/read/RowBatchTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/read/RowBatchTest.java
@@ -1330,13 +1330,18 @@ public class RowBatchTest {
 
     @Test
     public void testDatetimeTzVectorRecoversWallClock() throws IOException, DorisException {
-        // Instant 2026-08-24T02:00:09Z labeled +08:00 is wall clock 2026-08-24 10:00:09.
-        long milliEpoch = Instant.parse("2026-08-24T02:00:09Z").toEpochMilli();
+        long milliEpoch = 1721892143586L;
+        long offsetMilliEpoch = Instant.parse("2026-08-24T02:00:09Z").toEpochMilli();
+        Instant milliInstant = Instant.ofEpochMilli(milliEpoch);
         ImmutableList<Field> fields = ImmutableList.of(
                 new Field("k0", FieldType.nullable(
-                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "+08:00")), null),
+                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC+8")), null),
                 new Field("k1", FieldType.nullable(
-                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "+08:00")), null));
+                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC+8")), null),
+                new Field("k2", FieldType.nullable(
+                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "+08:00")), null),
+                new Field("k3", FieldType.nullable(
+                        new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC+8")), null));
         VectorSchemaRoot root = VectorSchemaRoot.create(
                 new org.apache.arrow.vector.types.pojo.Schema(fields, null),
                 new RootAllocator(Integer.MAX_VALUE));
@@ -1346,13 +1351,21 @@ public class RowBatchTest {
 
         writer.start();
         root.setRowCount(1);
-        TimeStampMilliTZVector datetimeVector = (TimeStampMilliTZVector) root.getVector("k0");
+        TimeStampMilliTZVector timestamptzVector = (TimeStampMilliTZVector) root.getVector("k0");
+        timestamptzVector.allocateNew(1);
+        timestamptzVector.setSafe(0, milliEpoch);
+        timestamptzVector.setValueCount(1);
+        TimeStampMilliTZVector datetimeVector = (TimeStampMilliTZVector) root.getVector("k1");
         datetimeVector.allocateNew(1);
         datetimeVector.setSafe(0, milliEpoch);
         datetimeVector.setValueCount(1);
-        TimeStampMilliTZVector datetimeV2Vector = (TimeStampMilliTZVector) root.getVector("k1");
+        TimeStampMilliTZVector offsetDatetimeVector = (TimeStampMilliTZVector) root.getVector("k2");
+        offsetDatetimeVector.allocateNew(1);
+        offsetDatetimeVector.setSafe(0, offsetMilliEpoch);
+        offsetDatetimeVector.setValueCount(1);
+        TimeStampMicroTZVector datetimeV2Vector = (TimeStampMicroTZVector) root.getVector("k3");
         datetimeV2Vector.allocateNew(1);
-        datetimeV2Vector.setSafe(0, milliEpoch);
+        datetimeV2Vector.setSafe(0, 1721892143586123L);
         datetimeV2Vector.setValueCount(1);
         writer.writeBatch();
         writer.end();
@@ -1366,21 +1379,34 @@ public class RowBatchTest {
         result.setRows(outputStream.toByteArray());
         Schema schema = MAPPER.readValue(
                 "{\"properties\":["
-                        + "{\"type\":\"DATETIME\",\"name\":\"k0\",\"comment\":\"\"},"
-                        + "{\"type\":\"DATETIMEV2\",\"name\":\"k1\",\"comment\":\"\"}],\"status\":200}",
+                        + "{\"type\":\"TIMESTAMPTZ\",\"name\":\"k0\",\"comment\":\"\"},"
+                        + "{\"type\":\"DATETIME\",\"name\":\"k1\",\"comment\":\"\"},"
+                        + "{\"type\":\"DATETIMEV2\",\"name\":\"k2\",\"comment\":\"\"},"
+                        + "{\"type\":\"DATETIMEV2\",\"name\":\"k3\",\"comment\":\"\"}],\"status\":200}",
                 Schema.class);
 
-        Timestamp expected = Timestamp.valueOf("2026-08-24 10:00:09");
-        List timestampRow = new RowBatch(result, schema, false).next();
-        Assert.assertEquals(expected, timestampRow.get(0));
-        Assert.assertEquals(expected, timestampRow.get(1));
+        Timestamp datetimeUtc8 = Timestamp.valueOf(
+                LocalDateTime.ofInstant(milliInstant, ZoneId.of("UTC+8")));
+        Timestamp datetimeOffset = Timestamp.valueOf("2026-08-24 10:00:09");
+        Timestamp datetimeV2Utc8 = Timestamp.valueOf(
+                LocalDateTime.ofInstant(
+                        Instant.ofEpochSecond(1721892143L, 586123000L), ZoneId.of("UTC+8")));
 
-        Instant expectedInstant = LocalDateTime.of(2026, 8, 24, 10, 0, 9)
-                .atZone(ZoneId.systemDefault())
-                .toInstant();
+        List timestampRow = new RowBatch(result, schema, false).next();
+        Assert.assertEquals(Timestamp.from(milliInstant), timestampRow.get(0));
+        Assert.assertEquals(datetimeUtc8, timestampRow.get(1));
+        Assert.assertEquals(datetimeOffset, timestampRow.get(2));
+        Assert.assertEquals(datetimeV2Utc8, timestampRow.get(3));
+        Assert.assertNotEquals(timestampRow.get(0), timestampRow.get(1));
+
         List instantRow = new RowBatch(result, schema, true).next();
-        Assert.assertEquals(expectedInstant, instantRow.get(0));
-        Assert.assertEquals(expectedInstant, instantRow.get(1));
+        Assert.assertEquals(milliInstant, instantRow.get(0));
+        Assert.assertEquals(datetimeUtc8.toLocalDateTime().atZone(ZoneId.systemDefault()).toInstant(),
+                instantRow.get(1));
+        Assert.assertEquals(datetimeOffset.toLocalDateTime().atZone(ZoneId.systemDefault()).toInstant(),
+                instantRow.get(2));
+        Assert.assertEquals(datetimeV2Utc8.toLocalDateTime().atZone(ZoneId.systemDefault()).toInstant(),
+                instantRow.get(3));
     }
 
     @Test

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/read/RowBatchTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/read/RowBatchTest.java
@@ -1329,6 +1329,61 @@ public class RowBatchTest {
     }
 
     @Test
+    public void testDatetimeTzVectorRecoversWallClock() throws IOException, DorisException {
+        // Instant 2026-08-24T02:00:09Z labeled +08:00 is wall clock 2026-08-24 10:00:09.
+        long milliEpoch = Instant.parse("2026-08-24T02:00:09Z").toEpochMilli();
+        ImmutableList<Field> fields = ImmutableList.of(
+                new Field("k0", FieldType.nullable(
+                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "+08:00")), null),
+                new Field("k1", FieldType.nullable(
+                        new ArrowType.Timestamp(TimeUnit.MILLISECOND, "+08:00")), null));
+        VectorSchemaRoot root = VectorSchemaRoot.create(
+                new org.apache.arrow.vector.types.pojo.Schema(fields, null),
+                new RootAllocator(Integer.MAX_VALUE));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ArrowStreamWriter writer = new ArrowStreamWriter(
+                root, new DictionaryProvider.MapDictionaryProvider(), outputStream);
+
+        writer.start();
+        root.setRowCount(1);
+        TimeStampMilliTZVector datetimeVector = (TimeStampMilliTZVector) root.getVector("k0");
+        datetimeVector.allocateNew(1);
+        datetimeVector.setSafe(0, milliEpoch);
+        datetimeVector.setValueCount(1);
+        TimeStampMilliTZVector datetimeV2Vector = (TimeStampMilliTZVector) root.getVector("k1");
+        datetimeV2Vector.allocateNew(1);
+        datetimeV2Vector.setSafe(0, milliEpoch);
+        datetimeV2Vector.setValueCount(1);
+        writer.writeBatch();
+        writer.end();
+        writer.close();
+
+        TStatus status = new TStatus();
+        status.setStatusCode(TStatusCode.OK);
+        TScanBatchResult result = new TScanBatchResult();
+        result.setStatus(status);
+        result.setEos(false);
+        result.setRows(outputStream.toByteArray());
+        Schema schema = MAPPER.readValue(
+                "{\"properties\":["
+                        + "{\"type\":\"DATETIME\",\"name\":\"k0\",\"comment\":\"\"},"
+                        + "{\"type\":\"DATETIMEV2\",\"name\":\"k1\",\"comment\":\"\"}],\"status\":200}",
+                Schema.class);
+
+        Timestamp expected = Timestamp.valueOf("2026-08-24 10:00:09");
+        List timestampRow = new RowBatch(result, schema, false).next();
+        Assert.assertEquals(expected, timestampRow.get(0));
+        Assert.assertEquals(expected, timestampRow.get(1));
+
+        Instant expectedInstant = LocalDateTime.of(2026, 8, 24, 10, 0, 9)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+        List instantRow = new RowBatch(result, schema, true).next();
+        Assert.assertEquals(expectedInstant, instantRow.get(0));
+        Assert.assertEquals(expectedInstant, instantRow.get(1));
+    }
+
+    @Test
     public void testLongToLocalDateTimeUsesDeclaredUnit() {
         ZoneId utc = ZoneId.of("UTC");
 


### PR DESCRIPTION
## What

`RowBatch.getDateTime` treated every timezone-aware Arrow timestamp as a `TIMESTAMPTZ` instant in the JVM default zone.

Doris `DATETIME` / `DATETIMEV2` store naive wall-clock digits. Some backends still emit Arrow `Timestamp` with a timezone (for example `+08:00`). The epoch instant plus that timezone is the original warehouse clock. Decoding in `ZoneId.systemDefault()` drops those digits (8 hours off when the JVM zone is GMT/UTC and Arrow is `+08:00`).

This change:

- `DATETIME` / `DATETIMEV2` with an Arrow timezone: decode in `ZoneId.of(arrowTz)`
- `TIMESTAMPTZ`: keep the current instant decode in the JVM default zone
- missing Arrow timezone: keep `getObject()` when it returns `LocalDateTime`

`Timestamp.valueOf` and the Java 8 Instant path are unchanged. They still treat the recovered `LocalDateTime` as local in the Spark JVM zone.

## Why 26.1.0 is not enough

https://github.com/apache/doris-spark-connector/pull/366 only special-cases a null Arrow timezone. Staging Doris still sends timezone-aware DATETIME, so 26.1.0 still prints the GMT face of the instant.

Doris core https://github.com/apache/doris/pull/65823 emits naive Arrow DATETIME. That is the long-term fix. This connector change covers backends that still send a timezone on DATETIME.

## Test plan

- [x] `RowBatchTest.testDatetimeTzVectorRecoversWallClock`: `DATETIME`/`DATETIMEV2` + `+08:00`, instant `2026-08-24T02:00:09Z` -> `Timestamp.valueOf("2026-08-24 10:00:09")`
- [x] `RowBatchTest.testTimestampTzVector` still passes
- [x] `RowBatchTest.testLongToLocalDateTimeUsesDeclaredUnit` still passes

```
cd spark-doris-connector
JAVA_TOOL_OPTIONS='--add-opens=java.base/java.nio=ALL-UNNAMED' \
  mvn -P spark-3.5 -pl spark-doris-connector-base test \
  -Dtest=RowBatchTest#testDatetimeTzVectorRecoversWallClock,RowBatchTest#testTimestampTzVector,RowBatchTest#testLongToLocalDateTimeUsesDeclaredUnit
```

## Related

We reproduced this on Spark 3.5 + connector 25.2.0 / 26.1.0 against a Doris FE that reports `time_zone=UTC`, with Arrow `TimeStampMilliTZVector` timezone `+08:00`.