### PR TITLE
[Improve] Reduce S3 TVF upload copying and log load timings

### DIFF
--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/tvf/S3ClientObjectStore.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/tvf/S3ClientObjectStore.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 
@@ -70,7 +71,10 @@ public final class S3ClientObjectStore implements S3ObjectStore {
                 .contentType(JSON_LINES_CONTENT_TYPE)
                 .build();
         try {
-            client.putObject(request, RequestBody.fromBytes(content));
+            client.putObject(request, RequestBody.fromContentProvider(
+                    () -> new ByteArrayInputStream(content),
+                    content.length,
+                    JSON_LINES_CONTENT_TYPE));
         } catch (RuntimeException e) {
             throw new IOException("Failed to upload S3 TVF object: " + objectKey, e);
         }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/tvf/S3TvfCommitter.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/tvf/S3TvfCommitter.java
@@ -19,15 +19,19 @@ package org.apache.doris.spark.client.write.tvf;
 
 import org.apache.doris.spark.config.DorisConfig;
 import org.apache.doris.spark.config.S3TvfOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 /** Commits one Spark partition with one Doris INSERT. */
 public final class S3TvfCommitter implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(S3TvfCommitter.class);
     private static final String COLUMNS = "columns";
     private static final String PARTIAL_COLUMNS = "partial_columns";
     private static final String FORMAT = "format";
@@ -59,11 +63,23 @@ public final class S3TvfCommitter implements AutoCloseable {
         if (committable.isEmpty()) {
             return;
         }
+        String insertSql = sqlBuilder.buildInsertSql(committable);
+        long insertStartedAtNanos = System.nanoTime();
         try {
             loadClient.executeInsert(
-                    sqlBuilder.buildInsertSql(committable),
+                    insertSql,
                     sessionVariables);
+            LOG.info("TVF insert completed, label={}, objectCount={}, insertTimeMs={}.",
+                    committable.getLabel(),
+                    committable.getObjectKeys().size(),
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - insertStartedAtNanos));
         } catch (SQLException e) {
+            LOG.warn("TVF insert failed, label={}, objectCount={}, insertTimeMs={}, SQLState={}, errorCode={}.",
+                    committable.getLabel(),
+                    committable.getObjectKeys().size(),
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - insertStartedAtNanos),
+                    e.getSQLState(),
+                    e.getErrorCode());
             throw new IOException(
                     "Doris INSERT failed for S3 TVF label " + committable.getLabel(), e);
         }

--- a/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/tvf/S3TvfWriter.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/main/java/org/apache/doris/spark/client/write/tvf/S3TvfWriter.java
@@ -23,15 +23,19 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /** Writes one logical Spark partition as deterministic JSON Lines objects. */
 public final class S3TvfWriter implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(S3TvfWriter.class);
     private static final byte NEW_LINE = '\n';
 
     private final S3TvfOptions options;
@@ -110,7 +114,21 @@ public final class S3TvfWriter implements AutoCloseable {
                 currentFileNumber);
         String prefix = options.getPrefix();
         String objectKey = prefix + (prefix.endsWith("/") ? "" : "/") + fileName;
-        objectStore.put(objectKey, content);
+        long uploadStartedAtNanos = System.nanoTime();
+        try {
+            objectStore.put(objectKey, content);
+            LOG.info("S3 TVF object upload completed, objectKey={}, sizeBytes={}, uploadTimeMs={}.",
+                    objectKey,
+                    content.length,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - uploadStartedAtNanos));
+        } catch (IOException | RuntimeException e) {
+            LOG.warn("S3 TVF object upload failed, objectKey={}, sizeBytes={}, uploadTimeMs={}.",
+                    objectKey,
+                    content.length,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - uploadStartedAtNanos),
+                    e);
+            throw e;
+        }
         objectKeys.add(objectKey);
         buffer.reset();
         recordCount = 0;

--- a/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/tvf/S3ClientObjectStoreTest.java
+++ b/spark-doris-connector/spark-doris-connector-base/src/test/java/org/apache/doris/spark/client/write/tvf/S3ClientObjectStoreTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.spark.client.write.tvf;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class S3ClientObjectStoreTest {
+    @Test
+    public void uploadBodyIsRepeatableWithoutCopying() throws Exception {
+        byte[] content = "{\"id\":1}\n".getBytes(StandardCharsets.UTF_8);
+        RequestBody[] captured = new RequestBody[1];
+        S3Client client = new S3Client() {
+            @Override
+            public PutObjectResponse putObject(PutObjectRequest request, RequestBody body) {
+                Assert.assertEquals("bucket", request.bucket());
+                Assert.assertEquals("prefix/file.json", request.key());
+                Assert.assertEquals("application/x-ndjson", request.contentType());
+                captured[0] = body;
+                return PutObjectResponse.builder().build();
+            }
+
+            @Override
+            public String serviceName() {
+                return "s3";
+            }
+
+            @Override
+            public void close() {}
+        };
+        try (S3ClientObjectStore store = new S3ClientObjectStore(client, "bucket")) {
+            store.put("prefix/file.json", content);
+            RequestBody body = captured[0];
+            Assert.assertEquals(content.length, body.optionalContentLength().get().longValue());
+            // Mutate only in this test to detect a defensive copy in the request body.
+            content[0] = '[';
+            try (DataInputStream first = new DataInputStream(body.contentStreamProvider().newStream());
+                    DataInputStream retry = new DataInputStream(body.contentStreamProvider().newStream())) {
+                Assert.assertEquals('[', first.read());
+                assertContent(retry, content);
+                byte[] remaining = new byte[content.length - 1];
+                System.arraycopy(content, 1, remaining, 0, remaining.length);
+                assertContent(first, remaining);
+            }
+            Assert.assertEquals("application/x-ndjson", body.contentType());
+        }
+    }
+
+    private static void assertContent(DataInputStream input, byte[] expected) throws IOException {
+        byte[] actual = new byte[expected.length];
+        input.readFully(actual);
+        Assert.assertArrayEquals(expected, actual);
+        Assert.assertEquals(-1, input.read());
+    }
+}


### PR DESCRIPTION
## Problem Summary

S3 TVF uploads copy each file again when creating the SDK request body, after the writer has already copied its buffer. Use a repeatable content provider to remove that extra copy while allowing retries to read the complete content again.

Add upload size and duration logs, and INSERT object count and duration logs, for both successful and failed operations. These changes apply to the shared base module used by Spark 2/3/4.

## Validation

- `S3ClientObjectStoreTest`: 1 test passed with the Spark 3.5 profile and JDK 17. Covers request metadata, absence of the extra copy, and independent streams for repeatable reads. The no-copy assertion fails on the original implementation.
- `git diff --check` passed.
- Real-cluster integration tests were not run.

## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added: Yes
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No
